### PR TITLE
Add release automation

### DIFF
--- a/.chglog/CHANGELOG.tpl.md
+++ b/.chglog/CHANGELOG.tpl.md
@@ -1,0 +1,46 @@
+{{ range .Versions }}
+<a name="{{ .Tag.Name }}"></a>
+## {{ if .Tag.Previous }}[Release {{ .Tag.Name }}]({{ $.Info.RepositoryURL }}/compare/{{ .Tag.Previous.Name }}...{{ .Tag.Name }}){{ else }}{{ .Tag.Name }}{{ end }}
+
+> Release Date: {{ datetime "2006-01-02" .Tag.Date }}
+
+{{ range .CommitGroups -}}
+### {{ .Title }}
+
+{{ range .Commits -}}
+- [{{ .Hash.Short }}]{{"\t"}}{{ .Subject }}{{ range .Refs }} (#{{ .Ref }}) {{ end }}
+{{ end }}
+{{ end -}}
+
+{{- if .RevertCommits -}}
+### ⏮ Reverts
+
+{{ range .RevertCommits -}}
+- [{{ .Hash.Short }}]{{"\t"}}{{ .Revert.Header }}{{ range .Refs }} (#{{ .Ref }}) {{ end }}
+{{ end }}
+{{ end -}}
+
+### ⚠️ BREAKING
+
+{{ range .Commits -}}
+{{ if .Notes -}}
+{{ if not .Merge -}}
+{{ if not (contains .Header "Update CHANGELOG for" ) -}}
+{{ .Subject }} [{{ .Hash.Short }}]:{{"\n"}}{{ range .Notes }}{{ .Body }}
+{{ end }}
+{{ end -}}
+{{ end -}}
+{{ end -}}
+{{ end -}}
+
+### 📖 Commits
+
+{{ range .Commits -}}
+{{ if not .Merge -}}
+{{ if not (contains .Header "Update CHANGELOG for" ) -}}
+- [{{ .Hash.Short }}]{{"\t"}}{{ .Header }}{{ range .Refs }} (#{{ .Ref }}) {{ end }}
+{{ end -}}
+{{ end -}}
+{{ end -}}
+
+{{ end -}}

--- a/.chglog/config.yml
+++ b/.chglog/config.yml
@@ -1,0 +1,33 @@
+style: github
+template: CHANGELOG.tpl.md
+info:
+  title: CHANGELOG
+  repository_url: https://github.com/embano1/ci-demo-app
+options:
+  commits:
+    filters:
+      Type:
+        - api
+        - pat
+        - chore
+        - fix
+        - docs
+  commit_groups:
+    title_maps:
+      api: 🤖 API
+      pat: 📖 Pattern Language
+      chore: 🧹 Chore
+      fix: 🐞 Fix
+      docs: 📚 Documentation
+  header:
+    pattern: "^(\\w*)\\:\\s(.*)$"
+    pattern_maps:
+      - Type
+      - Subject
+  refs:
+    actions:
+      - Closes
+      - Fixes
+  notes:
+    keywords:
+      - "BREAKING"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,60 @@
+name: Release
+
+on:
+  # release will only be created when ref is a tag starting with "v"
+  push:
+    tags:
+      - "v*"
+      
+  workflow_dispatch:
+    inputs:
+      tag:
+        required: true
+        type: string
+        description: Use this existing Git tag to create the release
+
+jobs:
+  release:
+    name: Create Release
+    timeout-minutes: 10
+    strategy:
+      matrix:
+        go-version: ["1.18"]
+        platform: ["ubuntu-latest"]
+    runs-on: ${{ matrix.platform }}
+    env:
+      TAG: ${{ github.event.inputs.tag }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
+        with:
+          fetch-depth: 0
+          ref: "main"
+
+      - name: Get short TAG
+        if: ${{ github.event_name != 'workflow_dispatch' }}
+        run: |
+            echo "Retrieving tag from Github ref"
+            echo "TAG=$(basename "${{ github.ref }}")" >> $GITHUB_ENV
+
+      - name: Create CHANGELOG for Release (tag)
+        env:
+          IMAGE: quay.io/git-chglog/git-chglog
+          # https://quay.io/repository/git-chglog/git-chglog from tag v0.14.2
+          IMAGE_SHA: 998e89dab8dd8284cfff5f8cfb9e9af41fe3fcd4671f2e86a180e453c20959e3
+        run: |
+          # generate CHANGELOG for this Github release tag only
+          echo "Using tag $TAG to create release notes"
+          docker run --rm -v $PWD:/workdir ${IMAGE}@sha256:${IMAGE_SHA} -o RELEASE_CHANGELOG.md $TAG
+
+          # send to job summary
+          cat RELEASE_CHANGELOG.md >> $GITHUB_STEP_SUMMARY
+
+      - name: Create Github Release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          echo "Using tag $TAG to create release"
+          gh release create -F RELEASE_CHANGELOG.md ${TAG} LICENSE README.md
+


### PR DESCRIPTION
Automatically creates a Github release when a (semantic) `v*` git `tag` is pushed to the repository. This is typically done like this:

```
git checkout main

# incorporate all changes to local main (change upstream ref accordingly)
git pull upstream/main

# set release variable
RELEASE=0.1.0

# create annotated tag
git tag -a $RELEASE -m "Release ${RELEASE}"

# push tags (change upstream ref accordingly)
git push upstream --follow-tags
```

This will trigger the `release` action workflow and create a Github release with release notes.

Alternatively, e.g. to create a release for an existing tag if it does not exist yet, the workflow supports the "dispatch" trigger. Go to `Actions -> Release -> Run Workflow` and enter the tag for which to create a (non-existing) release.

Example output for a first `v0.1.0` release:

(Note that Github replaces the issue refs in () with the full issue name here in this comment. This is not the case in the release notes though, see https://github.com/vmware/govmomi/releases/tag/v0.28.0 for an example rendering).

> Release Date: 2022-05-30

### 🐞 Fix

- [0587818]     Broken badges (#16)
- [e5c64be]     Use go v1.18 in linter (#22)

### 📚 Documentation

- [8356890]     add CONTRIBUTING.md (#18)

### 🧹 Chore

- [dc44524]     Add release automation (#31)
- [547559c]     Add codecov.io support (#28)
- [e7b58b3]     Use LFS and cache in unit tests (#13)
- [2567993]     Add repository badges (#8)
- [e4d548f]     Add Github Actions and Dependabot automation (#6)

### ⚠️ BREAKING

### 📖 Commits

- [dc44524]     chore: Add release automation (#31)
- [dee450c]     Unexpose some utilities; closes [#10](https://github.com/embano1/ci-demo-app/issues/10) (#10)
- [547559c]     chore: Add codecov.io support (#28)
- [733e3b8]     fixup! docs: add CONTRIBUTING.md
- [snip...]

Closes: #31
Signed-off-by: Michael Gasch <mgasch@vmware.com>