### PR TITLE
fix: Minor fixes in docs and style

### DIFF
--- a/arrays_test.go
+++ b/arrays_test.go
@@ -70,7 +70,6 @@ const bands = `{
 }`
 
 func TestArrayCorrectness(t *testing.T) {
-
 	// only pattern3 should match
 	pattern1 := `{"bands": { "members": { "given": [ "Mick" ], "surname": [ "Strummer" ] } } }`
 	pattern2 := `{"bands": { "members": { "given": [ "Wata" ], "role": [ "drums" ] } } }`

--- a/benchmarks_test.go
+++ b/benchmarks_test.go
@@ -14,9 +14,11 @@ import (
 
 const oneMeg = 1024 * 1024
 
-var cityLotsLock sync.Mutex
-var cityLotsLines [][]byte
-var cityLotsLineCount int
+var (
+	cityLotsLock      sync.Mutex
+	cityLotsLines     [][]byte
+	cityLotsLineCount int
+)
 
 func getCityLotsLines(t *testing.T) [][]byte {
 	cityLotsLock.Lock()
@@ -47,7 +49,6 @@ func getCityLotsLines(t *testing.T) [][]byte {
 }
 
 func TestCRANLEIGH(t *testing.T) {
-
 	jCranleigh := `{ "type": "Feature", "properties": { "MAPBLKLOT": "7222001", "BLKLOT": "7222001", "BLOCK_NUM": "7222", "LOT_NUM": "001", "FROM_ST": "1", "TO_ST": "1", "STREET": "CRANLEIGH", "ST_TYPE": "DR", "ODD_EVEN": "O" }, "geometry": { "type": "Polygon", "coordinates": [ [ [ -122.472773074480756, 37.73439178240811, 0.0 ], [ -122.47278111723567, 37.73451247621523, 0.0 ], [ -122.47242608711845, 37.73452184591072, 0.0 ], [ -122.472418368113281, 37.734401143064396, 0.0 ], [ -122.472773074480756, 37.73439178240811, 0.0 ] ] ] } }`
 	j108492 := `{ "type": "Feature", "properties": { "MAPBLKLOT": "0011008", "BLKLOT": "0011008", "BLOCK_NUM": "0011", "LOT_NUM": "008", "FROM_ST": "500", "TO_ST": "550", "STREET": "BEACH", "ST_TYPE": "ST", "ODD_EVEN": "E" }, "geometry": { "type": "Polygon", "coordinates": [ [ [ -122.418114728237924, 37.807058866808987, 0.0 ], [ -122.418261722815416, 37.807807921694092, 0.0 ], [ -122.417544151208375, 37.807900142836701, 0.0 ], [ -122.417397010603693, 37.807150305505004, 0.0 ], [ -122.418114728237924, 37.807058866808987, 0.0 ] ] ] } }`
 	m := newCoreMatcher()

--- a/core_matcher.go
+++ b/core_matcher.go
@@ -1,10 +1,13 @@
 package quamina
 
-// coreMatcher represents an automaton that allows matching sequences of name/value field pairs against
+// coreMatcher represents an automaton that allows matching sequences of
+// name/value field pairs against
 //  patterns, which are combinations of field names and lists of allowed valued field values.
-// The field names are called "Paths" because they encode, in a jsonpath-ish style, the pathSegments from the
+// The field names are called "Paths" because they encode, in a jsonpath-ish
+// style, the pathSegments from the
 //  root of an incoming object to the leaf field.
-// Since the order of fields is generally not significant in encoded data objects, the fields are sorted
+// Since the order of fields is generally not significant in encoded data
+// objects, the fields are sorted
 //  by name before constructing the automaton, and so are the incoming field lists to be matched, allowing
 //  the automaton to work.
 
@@ -32,9 +35,6 @@ type coreStart struct {
 	presumedExistFalseMatches *matchSet
 }
 
-// X for anything, should eventually be a generic?
-type X any
-
 func newCoreMatcher() *coreMatcher {
 	m := coreMatcher{}
 	m.updateable.Store(&coreStart{
@@ -44,6 +44,7 @@ func newCoreMatcher() *coreMatcher {
 	})
 	return &m
 }
+
 func (m *coreMatcher) start() *coreStart {
 	return m.updateable.Load().(*coreStart)
 }
@@ -146,7 +147,6 @@ type proposedTransition struct {
 // matchesForSortedFields runs the provided list of name/value pairs against the automaton and returns
 //  a possibly-empty list of the patterns that match
 func (m *coreMatcher) matchesForSortedFields(fields []Field) *matchSet {
-
 	failedExistsFalseMatches := newMatchSet()
 	matches := newMatchSet()
 
@@ -203,14 +203,16 @@ func (m *coreMatcher) matchesForSortedFields(fields []Field) *matchSet {
 
 // Arrays are invisible in the automaton.  That is to say, if an event has
 //  { "a": [ 1, 2, 3 ] }
-//  Then the fields will be a/1, a/2, and a/3
-//  Same for  {"a": [[1, 2], 3]} or any other permutation
-//  So if you have {"a": [ { "b": 1, "c": 2}, {"b": 3, "c": 4}] }
-//  then a pattern like { "a": { "b": 1, "c": 4 } } would match.
-// To prevent that from happening, each ArrayPos contains two numbers; the first identifies the array in
-//  the event that this name/val occurred in, the second the position in the array. We don't allow
-//  transitioning between field values that occur in different positions in the same array.
-//  See the arrays_test unit test for more examples.
+// Then the fields will be a/1, a/2, and a/3 Same for  {"a": [[1, 2], 3]} or any
+// other permutation So if you have
+//  {"a": [ { "b": 1, "c": 2}, {"b": 3, "c": 4}] }
+// then a pattern like
+//  { "a": { "b": 1, "c": 4 } }
+// would match. To prevent that from happening, each ArrayPos contains two
+// numbers; the first identifies the array in
+// the event that this name/val occurred in, the second the position in the array. We don't allow
+// transitioning between field values that occur in different positions in the same array.
+// See the arrays_test unit test for more examples.
 func noArrayTrailConflict(from []ArrayPos, to []ArrayPos) bool {
 	for _, fromAPos := range from {
 		for _, toAPos := range to {

--- a/external_test.go
+++ b/external_test.go
@@ -1,8 +1,9 @@
 package quamina_test
 
 import (
-	"github.com/timbray/quamina"
 	"testing"
+
+	"github.com/timbray/quamina"
 )
 
 type fakeFlattener struct {
@@ -12,6 +13,7 @@ type fakeFlattener struct {
 func (f *fakeFlattener) Flatten(_ []byte, _ quamina.NameTracker) ([]quamina.Field, error) {
 	return f.r, nil
 }
+
 func (f *fakeFlattener) Copy() quamina.Flattener {
 	return &fakeFlattener{r: f.r}
 }

--- a/field_matcher.go
+++ b/field_matcher.go
@@ -25,6 +25,7 @@ type fmFields struct {
 func (m *fieldMatcher) fields() *fmFields {
 	return m.updateable.Load().(*fmFields)
 }
+
 func (m *fieldMatcher) update(fields *fmFields) {
 	m.updateable.Store(fields)
 }
@@ -58,7 +59,6 @@ func newFieldMatcher() *fieldMatcher {
 }
 
 func (m *fieldMatcher) addTransition(field *patternField) []*fieldMatcher {
-
 	// we build the new updateable state in freshStart so we can blsat it in atomically once computed
 	current := m.fields()
 	freshStart := &fmFields{}
@@ -107,7 +107,6 @@ func (m *fieldMatcher) addTransition(field *patternField) []*fieldMatcher {
 //  would be if you had the pattern { "a": [ "foo" ] } and another pattern that matched any value with
 //  a prefix of "f".
 func (m *fieldMatcher) transitionOn(field *Field) []*fieldMatcher {
-
 	// are there transitions on this field name?
 	valMatcher, ok := m.fields().transitions[string(field.Path)]
 	if !ok {

--- a/flatten_json.go
+++ b/flatten_json.go
@@ -37,8 +37,11 @@ func (fj *flattenJSON) reset() {
 
 // JSON literals
 var trueBytes = []byte("true")
-var falseBytes = []byte("false")
-var nullBytes = []byte("null")
+
+var (
+	falseBytes = []byte("false")
+	nullBytes  = []byte("null")
+)
 
 // fjState - this is a finite state machine parser, or rather a collection of smaller FSM parsers. Some of these
 //  states are used in only one function, others in multiple places
@@ -394,8 +397,8 @@ func (fj *flattenJSON) readNumber() ([]byte, []byte, error) {
 			case ',', ']', '}', ' ', '\t', '\n', '\r':
 				fj.eventIndex--
 				// TODO: Too expensive; make it possible for people to ask for this
-				//bytes := fj.event[numStart : fj.eventIndex+1]
-				//c, err := canonicalize(bytes)
+				// bytes := fj.event[numStart : fj.eventIndex+1]
+				// c, err := canonicalize(bytes)
 				var alt []byte
 				//if err == nil {
 				//	alt = []byte(c)
@@ -457,7 +460,6 @@ func (fj *flattenJSON) readNumber() ([]byte, []byte, error) {
 }
 
 func (fj *flattenJSON) readLiteral(literal []byte) ([]byte, error) {
-
 	for _, literalCh := range literal {
 		if literalCh != fj.ch() {
 			return nil, fj.error("unknown literal")
@@ -496,7 +498,7 @@ func (fj *flattenJSON) readStringValue() ([]byte, error) {
 }
 
 func (fj *flattenJSON) readStringValWithEscapes(nameStart int) ([]byte, error) {
-	//pointing at '"'
+	// pointing at '"'
 	val := []byte{'"'}
 	var err error
 	from := nameStart + 1
@@ -625,7 +627,6 @@ func (fj *flattenJSON) readTextWithEscapes(from int) ([]byte, int, error) {
 // the from is the offset in fj.event. We return the UTF-8 byte slice, the new setting for fj.eventIndex after
 //  reading the escapes, and an error if the escape syntax is busted.
 func (fj *flattenJSON) readHexUTF16(from int) ([]byte, int, error) {
-
 	// in the case that there are multiple \uXXXX in a row, we need to read all of them because some of them
 	//  might be surrogate pairs. So, back up to point at the first \
 	var codepoints []uint16
@@ -701,6 +702,7 @@ func (fj *flattenJSON) storeArrayElementField(path []byte, val []byte) {
 	copy(f.ArrayTrail, fj.arrayTrail)
 	fj.fields = append(fj.fields, f)
 }
+
 func (fj *flattenJSON) storeObjectMemberField(path []byte, arrayTrail []ArrayPos, val []byte) {
 	fj.fields = append(fj.fields, Field{Path: path, ArrayTrail: arrayTrail, Val: val})
 }
@@ -709,9 +711,11 @@ func (fj *flattenJSON) enterArray() {
 	fj.arrayCount++
 	fj.arrayTrail = append(fj.arrayTrail, ArrayPos{fj.arrayCount, 0})
 }
+
 func (fj *flattenJSON) leaveArray() {
 	fj.arrayTrail = fj.arrayTrail[:len(fj.arrayTrail)-1]
 }
+
 func (fj *flattenJSON) stepOneArrayElement() {
 	fj.arrayTrail[len(fj.arrayTrail)-1].Pos++
 }

--- a/flatten_json_test.go
+++ b/flatten_json_test.go
@@ -16,13 +16,13 @@ func bequal(a []byte, b []byte) bool {
 	}
 	return true
 }
+
 func TestFJBasic(t *testing.T) {
 	j := `{ "a": 1, "b": "two", "c": true, "d": null, "e": { "e1": 2, "e2": 3.02e-5}, "f": [33e2, "x", true, false, null], "g": false}`
 	allYes := fakeMatcher("a", "b", "c", "d", "e", "e1", "e2", "f", "g")
 
 	f := newJSONFlattener()
 	list, err := f.Flatten([]byte(j), allYes)
-
 	if err != nil {
 		t.Error("E: " + err.Error())
 	}
@@ -56,7 +56,6 @@ func TestFJBasic(t *testing.T) {
 }
 
 func TestFJ10Lines(t *testing.T) {
-
 	geo := fakeMatcher("type", "geometry")
 	testTrackerSelection(newJSONFlattener(), geo, "L0", "testdata/cl-sample-0",
 		[]string{"type", "geometry\ntype"},
@@ -122,6 +121,7 @@ func TestMinimal(t *testing.T) {
 		t.Error("Name/Val wrong")
 	}
 }
+
 func testTrackerSelection(fj Flattener, tracker NameTracker, label string, filename string, wantedPaths []string, wantedVals []string, t *testing.T) {
 	event, err := ioutil.ReadFile(filename)
 	if err != nil {

--- a/flattener.go
+++ b/flattener.go
@@ -1,37 +1,41 @@
 package quamina
 
+// ArrayPos ... TODO
 type ArrayPos struct {
 	Array int32
 	Pos   int32
 }
+
+// Field ... TODO
 type Field struct {
 	Path       []byte
 	Val        []byte
 	ArrayTrail []ArrayPos
 }
 
-// Flattener is provided as an interface in the hope that flatterners for other non-JSON message formats might
-//  be implemented.
-// How it needs to work, by JSON example:
-// { "a": 1, "b": "two", "c": true", "d": nil, "e": { "e1": 2, "e2":, 3.02e-5} "f": [33, "x"]} }
+// Flattener is provided as an interface in the hope that flatterners for other
+// non-JSON message formats might be implemented. How it needs to work, by JSON
+// example:
+//  { "a": 1, "b": "two", "c": true", "d": nil, "e": { "e1": 2, "e2":, 3.02e-5} "f": [33, "x"]} }
 // should produce
-// "a", "1"
-// "b", "\"two\"",
-// "c", "true"
-// "d", "nil",
-// "e\ne1", "2"
-// "e\ne2", "3.02e-5"
-// "f", "33"
-// "f", "\"x\""
+//  "a", "1"
+//  "b", "\"two\"",
+//  "c", "true"
+//  "d", "nil",
+//  "e\ne1", "2"
+//  "e\ne2", "3.02e-5"
+//  "f", "33"
+//  "f", "\"x\""
 //
-// Let's call the first column, eg "d" and "e\ne1", the pathSegments. For each step i the pathSegments, e.g. "d" and "e1", the
-//  Flattener shold call nameTracker.IsNameUsed(step) and if that comes back negative, not include any paths which
-//  don't contain that step.
-// So in the example above, if nameTracker.IsNameUsed() only came back true for "a" and "f", then the output
-//  would be
-// "a", "1"
-// "f", "33"
-// "f", "\"x\""
+// Let's call the first column, eg "d" and "e\ne1", the pathSegments. For each
+// step i the pathSegments, e.g. "d" and "e1", the Flattener shold call
+// nameTracker.IsNameUsed(step) and if that comes back negative, not include any
+// paths which don't contain that step. So in the example above, if
+// nameTracker.IsNameUsed() only came back true for "a" and "f", then the output
+// would be
+//  "a", "1"
+//  "f", "33"
+//  "f", "\"x\""
 type Flattener interface {
 	Flatten(event []byte, tracker NameTracker) ([]Field, error)
 	Copy() Flattener

--- a/list_maker_test.go
+++ b/list_maker_test.go
@@ -48,5 +48,4 @@ func TestListMaker(t *testing.T) {
 	if len(lists) != wanted {
 		t.Errorf("Got %d STILL wanted %d", len(lists), wanted)
 	}
-
 }

--- a/live_pattern_state.go
+++ b/live_pattern_state.go
@@ -4,24 +4,22 @@ import (
 	"sync"
 )
 
-// LivePatternsState represents the required capabilities for
-// maintaining the set of live patterns.
+// LivePatternsState represents the required capabilities for maintaining the
+// set of live patterns.
 type LivePatternsState interface {
 	// Add adds a new pattern or updates an old pattern.
 	//
-	// Note that multiple patterns can be associated with the same
-	// X.
+	// Note that multiple patterns can be associated with the same X.
 	Add(x X, pattern string) error
 
-	// Delete removes all patterns associated with the given X and
-	// returns the number of removed patterns.
+	// Delete removes all patterns associated with the given X and returns the
+	// number of removed patterns.
 	Delete(x X) (int, error)
 
 	// Iterate calls the given function for every stored pattern.
 	Iterate(func(x X, pattern string) error) error
 
-	// Contains returns true if x is in the live set; false
-	// otherwise.
+	// Contains returns true if x is in the live set; false otherwise.
 	Contains(x X) (bool, error)
 }
 
@@ -32,8 +30,7 @@ type (
 
 var na = nothing{}
 
-// MemState is a LivePatternsState that is just a map (with a
-// RWMutex).
+// MemState is a LivePatternsState that is just a map (with a RWMutex).
 //
 // Since the LivePatternsState implementation can be provided to the
 // application, we're keeping things simple here initially.

--- a/matcher.go
+++ b/matcher.go
@@ -1,5 +1,8 @@
 package quamina
 
+// X for anything, should eventually be a generic? TODO
+type X any
+
 type matcher interface {
 	addPattern(x X, pat string) error
 	matchesForFields(fields []Field) ([]X, error)

--- a/name_tracker.go
+++ b/name_tracker.go
@@ -1,5 +1,6 @@
 package quamina
 
+// NameTracker ... TODO
 type NameTracker interface {
 	IsNameUsed(label []byte) bool
 }

--- a/numbers_test.go
+++ b/numbers_test.go
@@ -23,6 +23,7 @@ func TestBadNumbers(t *testing.T) {
 		t.Error("took huge number")
 	}
 }
+
 func TestVariants(t *testing.T) {
 	f := []string{
 		"350",

--- a/pattern_test.go
+++ b/pattern_test.go
@@ -60,27 +60,35 @@ func TestPatternFromJSON(t *testing.T) {
 		}},
 	}
 	w4 := []*patternField{
-		{path: "x", vals: []typedVal{
-			{vType: existsTrueType, val: ""},
+		{
+			path: "x", vals: []typedVal{
+				{vType: existsTrueType, val: ""},
+			},
 		},
-		}}
+	}
 	w5 := []*patternField{
-		{path: "x\ny", vals: []typedVal{
-			{vType: existsFalseType, val: ""},
+		{
+			path: "x\ny", vals: []typedVal{
+				{vType: existsFalseType, val: ""},
+			},
 		},
-		}}
+	}
 	w6 := []*patternField{
-		{path: "abc", vals: []typedVal{
-			{vType: stringType, val: "3"},
-			{vType: shellStyleType, val: `"a*b"`},
+		{
+			path: "abc", vals: []typedVal{
+				{vType: stringType, val: "3"},
+				{vType: shellStyleType, val: `"a*b"`},
+			},
 		},
-		}}
+	}
 	w7 := []*patternField{
-		{path: "abc", vals: []typedVal{
-			{vType: shellStyleType, val: `"a*b"`},
-			{vType: stringType, val: `"foo"`},
+		{
+			path: "abc", vals: []typedVal{
+				{vType: shellStyleType, val: `"a*b"`},
+				{vType: stringType, val: `"foo"`},
+			},
 		},
-		}}
+	}
 	wanted := [][]*patternField{w1, w2, w3, w4, w5, w6, w7}
 
 	for i, good := range goods {

--- a/pruner.go
+++ b/pruner.go
@@ -110,7 +110,6 @@ func newTooMuchFiltering(ratio float64, min int64) *tooMuchFiltering {
 
 // TODO: Figure out how to expose this through the Quamina type
 func (t *tooMuchFiltering) rebuild(added bool, s *prunerStats) bool {
-
 	if added {
 		// No need to think when we're adding a pattern since
 		// that operation cannot result in an increase of
@@ -232,7 +231,6 @@ func (m *prunerMatcher) MatchesForJSONEvent(event []byte) ([]X, error) {
 // quamina.coreMatcher.matchesForFields and then maybe rebuilds the
 // index.
 func (m *prunerMatcher) matchesForFields(fields []Field) ([]X, error) {
-
 	xs, err := m.Matcher.matchesForFields(fields)
 	if err != nil {
 		return nil, err

--- a/pruner_test.go
+++ b/pruner_test.go
@@ -21,7 +21,6 @@ func (m *prunerMatcher) printStats() {
 }
 
 func TestBasic(t *testing.T) {
-
 	var (
 		pat   = `{"likes":["tacos"]}`
 		id    = 1
@@ -174,7 +173,6 @@ func TestRebuildSome(t *testing.T) {
 			t.Fatal(s)
 		}
 	})
-
 }
 
 func TestTriggerTooManyFilteredDenom(t *testing.T) {
@@ -193,11 +191,9 @@ func TestTriggerTooManyFilteredDenom(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-
 }
 
 func TestTriggerRebuild(t *testing.T) {
-
 	// This test just checks that a rebuildWhileLocked was actually triggered.
 
 	var (
@@ -271,7 +267,6 @@ func TestTriggerRebuild(t *testing.T) {
 	if 0 == s.RebuildDuration {
 		t.Fatal(s.RebuildDuration)
 	}
-
 }
 
 type badState struct {
@@ -372,7 +367,6 @@ func TestFlattener(t *testing.T) {
 	if got[0] != 1 {
 		t.Fatal(got)
 	}
-
 }
 
 func TestMultiplePatternsWithSameId(t *testing.T) {
@@ -437,7 +431,6 @@ func TestMultiplePatternsWithSameId(t *testing.T) {
 	if s.Deleted != 2 {
 		t.Fatal(s.Deleted)
 	}
-
 }
 
 /* TODO: Figure out which flattenJSON to use post refactor

--- a/quamina.go
+++ b/quamina.go
@@ -79,9 +79,10 @@ func WithPatternDeletion(b bool) Option {
 	}
 }
 
-// WithPatternDeletion supplies the Quamina instance with a LivePatternState instance to be used to store
-//  the active patterns, i.e. those that have been added with AddPattern but not deleted with
-//  DeletePattern. This option call may not be provided more than once.
+// WithPatternStorage supplies the Quamina instance with a LivePatternState
+// instance to be used to store the active patterns, i.e. those that have been
+// added with AddPattern but not deleted with DeletePattern. This option call
+// may not be provided more than once.
 func WithPatternStorage(ps LivePatternsState) Option {
 	return func(q *Quamina) error {
 		if ps == nil {
@@ -116,9 +117,11 @@ func (q *Quamina) Copy() *Quamina {
 func (q *Quamina) AddPattern(x X, patternJSON string) error {
 	return q.matcher.addPattern(x, patternJSON)
 }
+
 func (q *Quamina) DeletePatterns(x X) error {
 	return q.matcher.deletePatterns(x)
 }
+
 func (q *Quamina) MatchesForEvent(event []byte) ([]X, error) {
 	fields, err := q.flattener.Flatten(event, q.matcher)
 	if err != nil {

--- a/rebuilding.go
+++ b/rebuilding.go
@@ -42,8 +42,7 @@ func (t *liveRatioTrigger) rebuild(added bool, s *prunerStats) bool {
 //
 // This type is not used anywhere; just here as an example and maybe
 // for future consideration.
-type neverTrigger struct {
-}
+type neverTrigger struct{}
 
 func newNeverTrigger() *neverTrigger {
 	return &neverTrigger{}

--- a/rebuilding_test.go
+++ b/rebuilding_test.go
@@ -29,7 +29,6 @@ func TestLiveRatioTrigger(t *testing.T) {
 	if r.rebuild(false, s) {
 		t.Fatal("shouldn't have fired")
 	}
-
 }
 
 func TestNeverTrigger(t *testing.T) {
@@ -47,7 +46,6 @@ func TestNeverTrigger(t *testing.T) {
 //
 // The types in question aren't uint(64) but maybe they should be.
 func (s prunerStats) sane() error {
-
 	if s.Live < 0 {
 		return fmt.Errorf("prunerStats.Live is negative")
 	}
@@ -65,7 +63,6 @@ func (s prunerStats) sane() error {
 	}
 
 	return nil
-
 }
 
 func (m *prunerMatcher) checkStats() error {

--- a/shell_style_test.go
+++ b/shell_style_test.go
@@ -29,12 +29,14 @@ func TestLongCase(t *testing.T) {
 		}
 	}
 }
+
 func newNfaWithStart(start *smallTable[*nfaStepList]) *valueMatcher {
 	vm := newValueMatcher()
 	state := &vmFields{startNfa: start}
 	vm.update(state)
 	return vm
 }
+
 func TestNfaMerging(t *testing.T) {
 	aMatches := []string{
 		`"Afoo"`,
@@ -44,8 +46,8 @@ func TestNfaMerging(t *testing.T) {
 		`"BAB"`,
 		`"Bbar"`,
 	}
-	var f1 = &fieldMatcher{}
-	var f2 = &fieldMatcher{}
+	f1 := &fieldMatcher{}
+	f2 := &fieldMatcher{}
 	nfa1, _ := makeShellStyleAutomaton([]byte(`"A*"`), f1)
 	nfa2, _ := makeShellStyleAutomaton([]byte(`"B*"`), f2)
 
@@ -74,7 +76,6 @@ func TestNfaMerging(t *testing.T) {
 			t.Error("Fail on " + match)
 		}
 	}
-
 }
 
 func TestMakeShellStyleAutomaton(t *testing.T) {

--- a/small_table.go
+++ b/small_table.go
@@ -1,8 +1,8 @@
 package quamina
 
 // dfaStep and nfaStep are used by the valueMatcher automaton - every step through the
-//  automaton requires a smallTable and for some of them, taking the step means you've matched a value and can
-//  transition to a new fieldMatcher, in which case the fieldTransitions slice will be non-nil
+// automaton requires a smallTable and for some of them, taking the step means you've matched a value and can
+// transition to a new fieldMatcher, in which case the fieldTransitions slice will be non-nil
 type dfaStep struct {
 	table            *smallTable[*dfaStep]
 	fieldTransitions []*fieldMatcher
@@ -38,23 +38,23 @@ const valueTerminator byte = 0xf5
 //  but I imagine organizing it this way is a bit more memory-efficient.  Suppose we want to model a table where
 //  byte values 3 and 4 map to ss1 and byte 0x34 maps to ss2.  Then the smallTable would look like:
 //  ceilings: 3,   5,    0x34, 0x35, byteCeiling
-//     steps: nil, &ss1, nil,  &ss2, nil
+//  steps: nil, &ss1, nil,  &ss2, nil
 //  invariant: The last element of ceilings is always byteCeiling
 // The motivation is that we want to build a state machine on byte values to implement things like prefixes and
-//  ranges of bytes.  This could be done simply with an array of size byteCeiling for each state in the machine,
-//  or a map[byte]S, but both would be size-inefficient, particularly in the case where you're implementing
-//  ranges.  Now, the step function is O(N) in the number of entries, but empirically, the number of entries is
-//  small even in large automata, so skipping throgh the ceilings list is measurably about the same speed as a map
-//  or array construct. One could imagine making step() smarter and do a binary search in the case where there are
-//  more than some number of entries. But I'm dubious, the ceilings field is []byte and running through a single-digit
-//  number of those has a good chance of minimizing memory fetches
+// ranges of bytes.  This could be done simply with an array of size byteCeiling for each state in the machine,
+// or a map[byte]S, but both would be size-inefficient, particularly in the case where you're implementing
+// ranges.  Now, the step function is O(N) in the number of entries, but empirically, the number of entries is
+// small even in large automata, so skipping throgh the ceilings list is measurably about the same speed as a map
+// or array construct. One could imagine making step() smarter and do a binary search in the case where there are
+// more than some number of entries. But I'm dubious, the ceilings field is []byte and running through a single-digit
+// number of those has a good chance of minimizing memory fetches
 type smallTable[S comparable] struct {
 	ceilings []byte
 	steps    []S
 }
 
 // newSmallTable mostly exists to enforce the constraint that every smallTable has a byteCeiling entry at
-//  the end, which smallTable.step totally depends on.
+// the end, which smallTable.step totally depends on.
 func newSmallTable[S comparable]() *smallTable[S] {
 	var sNil S // declared but not assigned, thus serves as nil
 	return &smallTable[S]{
@@ -74,12 +74,12 @@ func (t *smallTable[S]) step(utf8Byte byte) S {
 }
 
 // mergeDfas and mergeNfas compute the union of two valueMatch automata.  If you look up the textbook theory about this,
-//  they say to compute the set product for automata A and B and build A0B0, A0B1 … A1BN, A1B0 … but if you look
-//  at that you realize that many of the product states aren't reachable. So you compute A0B0 and then keep
-//  recursing on the transitions coming out, I'm pretty sure you get a correct result. I don't know if it's
-//  minimal or even avoids being wasteful.
-//  INVARIANT: neither argument is nil
-//  INVARIANT: To be thread-safe, no existing table can be updated except when we're building it
+// they say to compute the set product for automata A and B and build A0B0, A0B1 … A1BN, A1B0 … but if you look
+// at that you realize that many of the product states aren't reachable. So you compute A0B0 and then keep
+// recursing on the transitions coming out, I'm pretty sure you get a correct result. I don't know if it's
+// minimal or even avoids being wasteful.
+// INVARIANT: neither argument is nil
+// INVARIANT: To be thread-safe, no existing table can be updated except when we're building it
 func mergeDfas(existing, newStep *smallTable[*dfaStep]) *smallTable[*dfaStep] {
 	step1 := &dfaStep{table: existing}
 	step2 := &dfaStep{table: newStep}
@@ -104,7 +104,7 @@ func mergeOneDfaStep(step1, step2 *dfaStep, memoize map[dfaStepKey]*dfaStep) *df
 	}
 
 	// TODO: this works, all the tests pass, but I'm not satisfied with it. My intuition is that you ought
-	//  to be able to come out of this with just one *fieldMatcher
+	// to be able to come out of this with just one *fieldMatcher
 	newTable := newSmallTable[*dfaStep]()
 	switch {
 	case step1.fieldTransitions == nil && step2.fieldTransitions == nil:

--- a/small_table_test.go
+++ b/small_table_test.go
@@ -35,8 +35,8 @@ func tMST(t *testing.T, b []byte) {
 func newDfaTransition(f *fieldMatcher) *dfaStep {
 	return &dfaStep{table: newSmallTable[*dfaStep](), fieldTransitions: []*fieldMatcher{f}}
 }
-func TestCombiner(t *testing.T) {
 
+func TestCombiner(t *testing.T) {
 	// "jab"
 	A0 := &dfaStep{table: newSmallTable[*dfaStep]()}
 	A1 := &dfaStep{table: newSmallTable[*dfaStep]()}
@@ -111,7 +111,6 @@ func TestCombiner(t *testing.T) {
 }
 
 func TestUnpack(t *testing.T) {
-
 	st1 := &dfaStep{table: newSmallTable[*dfaStep]()}
 
 	st := smallTable[*dfaStep]{

--- a/stats.go
+++ b/stats.go
@@ -84,6 +84,7 @@ func dfaStats(t *smallTable[*dfaStep], s *stats) {
 		}
 	}
 }
+
 func nfaStats(t *smallTable[*nfaStepList], s *stats) {
 	if s.stVisited[t] {
 		return


### PR DESCRIPTION
Ran `gofumpt -w .` to force style.

The comments were off (your editor seems to add two spaces in subsequent comments - this throws off the godoc interpreter. Examples/explanation:

```go
// this is a broken
//  comment because only one space allowed after //

// this is a good comment because two spaces will render syntax highlighting
//  {"rendered":"withhighlighting"}

// this is a normal and 
// good comment
```

You can check how the stuff gets rendered with:

```shell
go install golang.org/x/tools/cmd/godoc@latest

# from within your project where go.mod lives
godoc -http :6060 # open page and click on your project
```

I left some `TODO` in certain doc strings for exposed types/functions which need to be added/clarified.

Signed-off-by: Michael Gasch <mgasch@vmware.com>