### PR TITLE
Bug Fix: exists:false failures are not pruned from match set depending on order

### DIFF
--- a/core_matcher.go
+++ b/core_matcher.go
@@ -200,6 +200,9 @@ func (m *coreMatcher) matchesForSortedFields(fields []Field) *matchSet {
 			matches = matches.addX(presumedExistsFalseMatch)
 		}
 	}
+
+	// prune any invalidated exists:false matches from the set
+	matches = matches.removeX(failedExistsFalseMatches.matches()...)
 	return matches
 }
 

--- a/core_matcher_test.go
+++ b/core_matcher_test.go
@@ -122,6 +122,37 @@ func TestExerciseMatching(t *testing.T) {
 	fmt.Println(matcherStats(m))
 }
 
+func TestExistsFalseOrder(t *testing.T) {
+	j := `{
+		"aField": "a",
+		"bField": "b",
+		"cField": "c"
+	}`
+
+	// make sure exists:false properly disqualifies a match regardless of where
+	// it occurs (lexicographically) in the pattern
+	shouldNotMatches := []string{
+		`{ "aField": [ { "exists": false } ], "bField": [ "b" ], "cField": [ "c" ] }`,
+		`{ "aField": [ "a" ], "bField": [ { "exists": false } ], "cField": [ "c" ] }`,
+		`{ "aField": [ "a" ], "bField": [ "b" ], "cField": [ { "exists": false } ] }`,
+	}
+
+	for i, shouldNot := range shouldNotMatches {
+		m := newCoreMatcher()
+		err := m.addPattern(fmt.Sprintf("should NOT %d", i), shouldNot)
+		if err != nil {
+			t.Error("addPattern: " + shouldNot + ": " + err.Error())
+		}
+		matches, err := m.matchesForJSONEvent([]byte(j))
+		if err != nil {
+			t.Error("ShouldNot " + shouldNot + ": " + err.Error())
+		}
+		if len(matches) != 0 {
+			t.Error(shouldNot + " matched but shouldn't have")
+		}
+	}
+}
+
 func TestSimpleaddPattern(t *testing.T) {
 	// laboriously hand-check the simplest possible automaton
 	var x X = "testing"

--- a/match_set.go
+++ b/match_set.go
@@ -22,6 +22,18 @@ func (m *matchSet) addX(exes ...X) *matchSet {
 	return &matchSet{set: newSet}
 }
 
+func (m *matchSet) removeX(exes ...X) *matchSet {
+	// for concurrency, can't update in place
+	newSet := make(map[X]bool, len(m.set))
+	for k := range m.set {
+		newSet[k] = true
+	}
+	for _, x := range exes {
+		delete(newSet, x)
+	}
+	return &matchSet{set: newSet}
+}
+
 func (m *matchSet) contains(x X) bool {
 	_, ok := m.set[x]
 	return ok


### PR DESCRIPTION
First, thank you for the excellent library! I believe I've encountered a somewhat sneaky bug.

In short, presumed `exists:false` matches that have been invalidated are not pruned from the match set unless the path of the `exists:false` field comes last after sorting. The proposals are processed in reverse order, and unless the exists:false field is processed first, it is added to the match set [here](https://github.com/timbray/quamina/blob/cbaf72026561bcb8fd13f783a2d22ca8b7e5b547/core_matcher.go#L181), but is never removed.

I've implemented a simple test case [here](https://github.com/timbray/quamina/commit/6474b35e795ad4f4bfa9cde326a64f9771e29341) that fails on `main`.

The fix I've implemented is to remove the items in `failedExistsFalseMatches` from the `matches` set before returning. I'm not sure if this is the optimal fix, so let me know if there's a better way to achieve this.