### PR TITLE
Fixes #115

### DIFF
--- a/core_matcher.go
+++ b/core_matcher.go
@@ -41,7 +41,6 @@ type coreStart struct {
 }
 
 func newCoreMatcher() *coreMatcher {
-
 	// because of the way the matcher works, to serve its purpose of ensuring that "exists":false maches
 	// will be detected, the Path has to be lexically greater than any field path that appears in
 	// "exists":false. The value with byteCeiling works because that byte can't actually appear in any
@@ -169,7 +168,6 @@ func (m *coreMatcher) matchesForFields(fields []Field) ([]X, error) {
 // 1 or more transitions to other states, it calls itself recursively to see if any of the remaining fields
 // can continue the process by matching that state.
 func tryToMatch(fields []Field, index int, state *fieldMatcher, matches *matchSet, incomingEFMs map[string]*fieldMatcher) {
-
 	// finished?
 	if index == len(fields) {
 		return
@@ -215,7 +213,6 @@ func tryToMatch(fields []Field, index int, state *fieldMatcher, matches *matchSe
 
 	// for each state in the possibly-empty list of transitions from this state on fields[index]
 	for _, nextState := range nextStates {
-
 		// if arriving at this state means we've matched one or more patterns, record that fact
 		matches = matches.addXSingleThreaded(nextState.fields().matches...)
 

--- a/core_matcher.go
+++ b/core_matcher.go
@@ -181,13 +181,19 @@ func tryToMatch(fields []Field, index int, state *fieldMatcher, matches *matchSe
 	// all this looks expensive but in most cases both incoming and state efm signals will be empty, thus a no-op
 	efmsFromState := state.fields().pendingExistsFalses
 
-	// newEFMs = incomingEFMs + efmsFromState
-	newEFMs := make(map[string]*fieldMatcher, len(efmsFromState)+len(incomingEFMs))
-	for path, trans := range incomingEFMs {
-		newEFMs[path] = trans
-	}
-	for path, trans := range efmsFromState {
-		newEFMs[path] = trans
+	// newEFMs = incomingEFMs + efmsFromState, but bypass unless there's actually some exists:false action
+	var newEFMs map[string]*fieldMatcher
+	efmCount := len(efmsFromState) + len(incomingEFMs)
+	if efmCount > 0 {
+		newEFMs = make(map[string]*fieldMatcher, efmCount)
+		for path, trans := range incomingEFMs {
+			newEFMs[path] = trans
+		}
+		for path, trans := range efmsFromState {
+			newEFMs[path] = trans
+		}
+	} else {
+		newEFMs = incomingEFMs
 	}
 
 	// the list in which we'll store any states we'll be processing transitions to as a result of this field

--- a/core_matcher.go
+++ b/core_matcher.go
@@ -19,28 +19,43 @@ import (
 )
 
 // coreMatcher uses a finite automaton to implement the matchesForJSONEvent and MatchesForFields functions.
-// state is the start of the automaton
-// namesUsed is a map of field names that are used in any of the patterns that this automaton encodes. Typically,
-// patterns only consider a subset of the fields in an incoming data object, and there is no reason to consider
-// fields that do not appear in patterns when using the automaton for matching
-// the updateable fields are grouped into the coreStart member so they can be updated atomically using atomic.Load()
+// The updateable fields are grouped into the coreStart member so they can be updated atomically using atomic.Load()
 // and atomic.Store(). This is necessary for coreMatcher to be thread-safe.
 type coreMatcher struct {
 	updateable atomic.Value // always holds a *coreStart
 	lock       sync.Mutex
 }
+
+// coreStart groups the updateable fields in coreMatcher.
+// state is the start of the automaton.
+// namesUsed is a map of field names that are used in any of the patterns that this automaton encodes. Typically,
+// patterns only consider a subset of the fields in an incoming data object, and there is no reason to consider
+// fields that do not appear in patterns when using the automaton for matching.
+// fakeField is used when the flattener for an event returns no fields, because it could still match if
+// there were patterns with "exists":false. So in this case we run one fake field through the matcher
+// which will cause it to notice that any "exists":false patterns should match.
 type coreStart struct {
-	state                     *fieldMatcher
-	namesUsed                 map[string]bool
-	presumedExistFalseMatches *matchSet
+	state     *fieldMatcher
+	namesUsed map[string]bool
+	fakeField []Field
 }
 
 func newCoreMatcher() *coreMatcher {
+
+	// because of the way the matcher works, to serve its purpose of ensuring that "exists":false maches
+	// will be detected, the Path has to be lexically greater than any field path that appears in
+	// "exists":false. The value with byteCeiling works because that byte can't actually appear in any
+	// user-supplied path-name because it's not valid in UTF-8
+	fake := Field{
+		Path:       []byte{byte(byteCeiling)},
+		Val:        []byte(""),
+		ArrayTrail: []ArrayPos{{0, 0}},
+	}
 	m := coreMatcher{}
 	m.updateable.Store(&coreStart{
-		state:                     newFieldMatcher(),
-		namesUsed:                 make(map[string]bool),
-		presumedExistFalseMatches: newMatchSet(),
+		state:     newFieldMatcher(),
+		namesUsed: make(map[string]bool),
+		fakeField: []Field{fake},
 	})
 	return &m
 }
@@ -71,16 +86,13 @@ func (m *coreMatcher) addPattern(x X, patternJSON string) error {
 	freshStart.namesUsed = make(map[string]bool)
 	current := m.start()
 	freshStart.state = current.state
+	freshStart.fakeField = current.fakeField
 
 	for k := range current.namesUsed {
 		freshStart.namesUsed[k] = true
 	}
 	for used := range patternNamesUsed {
 		freshStart.namesUsed[used] = true
-	}
-	freshStart.presumedExistFalseMatches = newMatchSet()
-	for presumedExistsFalseMatch := range current.presumedExistFalseMatches.set {
-		freshStart.presumedExistFalseMatches = freshStart.presumedExistFalseMatches.addX(presumedExistsFalseMatch)
 	}
 
 	// now we add each of the name/value pairs in fields slice to the automaton, starting with the start state -
@@ -90,13 +102,13 @@ func (m *coreMatcher) addPattern(x X, patternJSON string) error {
 	for _, field := range patternFields {
 		var nextStates []*fieldMatcher
 		for _, state := range states {
-			ns := state.addTransition(field)
-
-			// special handling for exists:false, in which case there can be only one val and one next state
+			var ns []*fieldMatcher
 			if field.vals[0].vType == existsFalseType {
-				ns[0].addExistsFalseFailure(x)
-				freshStart.presumedExistFalseMatches = freshStart.presumedExistFalseMatches.addX(x)
+				ns = state.addExistsFalseTransition(field)
+			} else {
+				ns = state.addTransition(field)
 			}
+
 			nextStates = append(nextStates, ns...)
 		}
 		states = nextStates
@@ -106,9 +118,7 @@ func (m *coreMatcher) addPattern(x X, patternJSON string) error {
 	//  by matching each field in the pattern so update the matches value to indicate this (skipping those that
 	//  are only there to serve exists:false processing)
 	for _, endState := range states {
-		if !endState.fields().existsFalseFailures.contains(x) {
-			endState.addMatch(x)
-		}
+		endState.addMatch(x)
 	}
 	m.updateable.Store(freshStart)
 
@@ -129,76 +139,95 @@ func (m *coreMatcher) matchesForJSONEvent(event []byte) ([]X, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	// see the commentary on coreMatcher for an explanation of this.
+	// tl;dr: If the flattener returns no fields because there's nothing in the event that's mentioned in
+	// any patterns, the event could still match if there are only "exists":false patterns.
+	if len(fields) == 0 {
+		fields = m.start().fakeField
+	}
+
 	return m.matchesForFields(fields)
 }
 
-// matchesForFields takes a list of Field structures and sorts them by pathname; the fields in a pattern to
-// matched are similarly sorted; thus running an automaton over them works
+// matchesForFields takes a list of Field structures, sorts them by pathname, and launches the field-matching
+// process. The fields in a pattern to match are similarly sorted; thus running an automaton over them works
 func (m *coreMatcher) matchesForFields(fields []Field) ([]X, error) {
 	sort.Slice(fields, func(i, j int) bool { return string(fields[i].Path) < string(fields[j].Path) })
-	return m.matchesForSortedFields(fields).matches(), nil
-}
-
-// proposedTransition represents a suggestion that the name/value pair at fields[fieldIndex] might allow a transition
-// in the indicated state
-type proposedTransition struct {
-	matcher    *fieldMatcher
-	fieldIndex int
-}
-
-// matchesForSortedFields runs the provided list of name/value pairs against the automaton and returns
-// a possibly-empty list of the patterns that match
-func (m *coreMatcher) matchesForSortedFields(fields []Field) *matchSet {
-	failedExistsFalseMatches := newMatchSet()
 	matches := newMatchSet()
 
-	// The idea is that we add potential field transitions to the proposals list; any time such a transition
-	// succeeds, i.e. matches a particular field and moves to a new state, we propose transitions from that
-	// state on all the following fields in the event
-	// Start by giving each field a chance to match against the start state. Doing it by pre-allocating the
-	// proposals and filling in their values is observably faster than the more idiomatic append()
-	proposals := make([]proposedTransition, len(fields))
+	// for each of the fields, we'll try to match the automaton start state to that field - the tryToMatch
+	// routine will, in the case that there's a match, call itself to see if subsequent fields after the
+	// first matched will transition through the machine and eventually achieve a match
 	for i := range fields {
-		proposals[i].fieldIndex = i
-		proposals[i].matcher = m.start().state
+		tryToMatch(fields, i, m.start().state, matches, make(map[string]*fieldMatcher))
+	}
+	return matches.matches(), nil
+}
+
+// tryToMatch tries to match the field at fields[index] to the provided state. If it does match and generate
+// 1 or more transitions to other states, it calls itself recursively to see if any of the remaining fields
+// can continue the process by matching that state.
+func tryToMatch(fields []Field, index int, state *fieldMatcher, matches *matchSet, incomingEFMs map[string]*fieldMatcher) {
+
+	// finished?
+	if index == len(fields) {
+		return
 	}
 
-	// as long as there are still potential transitions
-	for len(proposals) > 0 {
-		// go slices could usefully have a "pop" primitive
-		lastIndex := len(proposals) - 1
-		proposal := proposals[lastIndex]
-		proposals = proposals[0:lastIndex]
+	fieldPath := fields[index].Path
 
-		// generate the possibly-empty list of transitions from state on the name/value pair
-		nextStates := proposal.matcher.transitionOn(&fields[proposal.fieldIndex])
+	// in the following discussion, "efm" and "EFM" stand for "exists":false matches.
+	// first, we construct the efmSignal going forward, which is the merger of any incoming ones from
+	// previous states and any in the signal for this state
+	// all this looks expensive but in most cases both incoming and state efm signals will be empty, thus a no-op
+	efmsFromState := state.fields().pendingExistsFalses
 
-		// for each state in the set of transitions from the proposed state
-		for _, nextState := range nextStates {
-			// if arriving at this state means we've matched one or more patterns, record that fact
-			matches = matches.addXSingleThreaded(nextState.fields().matches...)
+	// newEFMs = incomingEFMs + efmsFromState
+	newEFMs := make(map[string]*fieldMatcher, len(efmsFromState)+len(incomingEFMs))
+	for path, trans := range incomingEFMs {
+		newEFMs[path] = trans
+	}
+	for path, trans := range efmsFromState {
+		newEFMs[path] = trans
+	}
 
-			// have we invalidated a presumed exists:false pattern?
-			for existsMatch := range nextState.fields().existsFalseFailures.set {
-				failedExistsFalseMatches = failedExistsFalseMatches.addXSingleThreaded(existsMatch)
-			}
+	// the list in which we'll store any states we'll be processing transitions to as a result of this field
+	var nextStates []*fieldMatcher
 
-			// for each state we've transitioned to, give each subsequent field a chance to
-			//  transition on it, assuming it's not in an object that's in a different element
-			//  of the same array
-			for nextIndex := proposal.fieldIndex + 1; nextIndex < len(fields); nextIndex++ {
-				if noArrayTrailConflict(fields[proposal.fieldIndex].ArrayTrail, fields[nextIndex].ArrayTrail) {
-					proposals = append(proposals, proposedTransition{fieldIndex: nextIndex, matcher: nextState})
-				}
+	// now we'll look at the pending EFMs to see if any have succeeded or failed
+	for efmPath, trans := range newEFMs {
+		switch {
+		case string(fieldPath) < efmPath:
+			// no-op, we haven't got to a path lexically >= the one this signal is looking for
+		case string(fieldPath) == efmPath:
+			// the path that appeared in an exists:false exists, so we will delete it from the pending list
+			delete(newEFMs, efmPath)
+		case string(fieldPath) > efmPath:
+			// we have lexically passed the path that appeared in an exists:false and it's still pending,
+			// so this exists:false must have matched, save the associated transition for later processing
+			nextStates = []*fieldMatcher{trans}
+		}
+	}
+
+	// try to transition through the machine
+	nextStates = append(nextStates, state.transitionOn(&fields[index])...)
+
+	// for each state in the possibly-empty list of transitions from this state on fields[index]
+	for _, nextState := range nextStates {
+
+		// if arriving at this state means we've matched one or more patterns, record that fact
+		matches = matches.addXSingleThreaded(nextState.fields().matches...)
+
+		// for each state we've transitioned to, give each subsequent field a chance to
+		//  transition on it, assuming it's not in an object that's in a different element
+		//  of the same array
+		for nextIndex := index + 1; nextIndex < len(fields); nextIndex++ {
+			if noArrayTrailConflict(fields[index].ArrayTrail, fields[nextIndex].ArrayTrail) {
+				tryToMatch(fields, nextIndex, nextState, matches, newEFMs)
 			}
 		}
 	}
-	for presumedExistsFalseMatch := range m.start().presumedExistFalseMatches.set {
-		if !failedExistsFalseMatches.contains(presumedExistsFalseMatch) {
-			matches = matches.addXSingleThreaded(presumedExistsFalseMatch)
-		}
-	}
-	return matches
 }
 
 func noArrayTrailConflict(from []ArrayPos, to []ArrayPos) bool {

--- a/pattern.go
+++ b/pattern.go
@@ -21,6 +21,8 @@ const (
 	anythingButType
 )
 
+// typedVal represents a field from a parsed Pattern. The list member is only used for
+// anything-but matching
 type typedVal struct {
 	vType valType
 	val   string


### PR DESCRIPTION
Signed-off-by: Tim Bray <tbray@textuality.com>

This addresses `"exists":false` issues discovered by [kylemcc](https://github.com/kylemcc) who also provided a useful unit test. The previous implementation was badly broken and this is rebuilt from scratch.

The changes are medium-sized, not huge. Reviews would be welcome; one thing I'm specially interested in is whether the explanation of how exists:false works is actually comprehensible - I'm way too close to the problem. You don't have to go diving into the details of the state machine to understand (I hope).