### PR TITLE
fix: double escaping in skipString

### DIFF
--- a/flatten_json.go
+++ b/flatten_json.go
@@ -528,6 +528,12 @@ func (fj *flattenJSON) skipStringValue() error {
 	for i < len(data) {
 		c := data[i]
 
+		// Ignore double slashes (double escaped values)
+		if c == '\\' && i+1 < len(data) && data[i+1] == '\\' {
+			i = i + 2
+			continue
+		}
+
 		// Since we want to iterate until we found quote (") we need to take care
 		// about escaped quotes (\"), any other escaped characters is not relevant.
 		if c == '\\' && i+1 < len(data) && data[i+1] == '"' {

--- a/flatten_json_test.go
+++ b/flatten_json_test.go
@@ -36,6 +36,7 @@ func TestFJStrings(t *testing.T) {
 	j := `{
 		"skipped_escaped_string": "\"hello\"",
 		"skipped_escaped_string_in_middle": "\"hello\" world",
+		"two_escaping": "\"hello\" world \\",
 		"skipped_normal_string": "abc",
 		"normal_string": "abc",
 		"escaped_string": "\"hello\"",


### PR DESCRIPTION
This event:
```json
{ "message" : "docs: change \" -> \\" }
```

Would cause an error until now.

fixes: https://github.com/timbray/quamina/issues/150