### PR TITLE
fix: handle nested objects when skipping unused fields

### DIFF
--- a/flatten_json.go
+++ b/flatten_json.go
@@ -168,7 +168,7 @@ func (fj *flattenJSON) readObject(pathNode SegmentsTreeTracker) error {
 			if pathNode.IsRoot() {
 				return errEarlyStop
 			} else {
-				return fj.skipUntil('}')
+				return fj.leaveObject()
 			}
 		}
 
@@ -532,7 +532,7 @@ func (fj *flattenJSON) readLiteral(literal []byte) ([]byte, error) {
 	return literal, nil
 }
 
-func (fj *flattenJSON) skipUntil(symbol byte) error {
+func (fj *flattenJSON) leaveObject() error {
 	for fj.eventIndex < len(fj.event) {
 		ch := fj.event[fj.eventIndex]
 
@@ -542,7 +542,14 @@ func (fj *flattenJSON) skipUntil(symbol byte) error {
 			if err != nil {
 				return err
 			}
-		case symbol:
+		case '{', '[':
+			// ch+2 is the matching closing brace, since both '}' and ']' are 2 characters away
+			// from '{' and ']', respectively
+			err := fj.skipBlock(ch, ch+2)
+			if err != nil {
+				return err
+			}
+		case '}':
 			return nil
 		}
 


### PR DESCRIPTION
Hopefully this is a fairly straightforward bug fix.

There is a small bug in the flattener when skipping the remaining fields of an event after all nodes/fields in supplied patterns have been evaluated. In the case where one of the additional fields is an object (or an object inside an array), the flattener will exit early at the first `}` it encounters.

If there are additional fields to match, the flattener will attempt to continue processing the event. However, the event index will be incorrectly pointed at the end of the next object it encounters, rather than the end of the object currently being processed.

Take the following event and paths, for example:

```json
{ "nested": { "value": "something", "bad": {} } }
```
```json
[ "nested\nvalue", "anotherField" ]
```

When the flattener finishes processing `nested.value`, it will determine that there aren't any more fields to process inside of `nested` and will skip to the end. However, the flattener currently looks for the first `}` it encounters, which, in this case, is the closing `}` of the sub-object `bad`. It will then return the error: `garbage char '}' after top-level object`

This updates the flattener to instead look for the closing `}` of the current object, handling arrays and objects within the current object.