### PR TITLE
docs: fix links

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 [![Tests](https://github.com/timbray/quamina/actions/workflows/go-unit-tests.yaml/badge.svg)](https://github.com/timbray/quamina/actions/workflows/go-unit-tests.yaml)
 [![Latest Release](https://img.shields.io/github/release/timbray/quamina.svg?logo=github&style=flat-square)](https://github.com/timbray/quamina/releases/latest)
 [![codecov](https://codecov.io/gh/timbray/quamina/branch/main/graph/badge.svg?token=TC7MW723JO)](https://codecov.io/gh/timbray/quamina)
-[![Go Report Card](https://goreportcard.com/badge/github.com/timbray/quamina)](https://goreportcard.com/report/github.com/timbray/quamina)
+[![Go Report Card](https://goreportcard.com/badge/quamina.net/go/quamina)](https://goreportcard.com/report/quamina.net/go/quamina)
 [![timbray/quamina](https://img.shields.io/github/go-mod/go-version/timbray/quamina)](https://github.com/timbray/quamina)
-[![Go Reference](https://pkg.go.dev/badge/github.com/timbray/quamina.svg)](https://pkg.go.dev/github.com/timbray/quamina)
+[![Go Reference](https://pkg.go.dev/badge/quamina.net/go/quamina.svg)](https://pkg.go.dev/quamina.net/go/quamina)
 [![Mentioned in Awesome Go](https://awesome.re/mentioned-badge.svg)](https://github.com/avelino/awesome-go)
 
 ### Fast pattern-matching library


### PR DESCRIPTION
Reflect go module name in `README` links.

Closes: #246