### PR TITLE
Issue 252

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -24,3 +24,8 @@ linters:
     - whitespace
     # wastedassign is disabled because of generics. You can track the evolution of the generics support by following the https://github.com/golangci/golangci-lint/issues/2649
     # - wastedassign
+
+issues:
+  exclude-rules:
+    - path: _test\.go
+      text: "Use of weak random number generator" #gosec:G404

--- a/PATTERNS.md
+++ b/PATTERNS.md
@@ -105,7 +105,7 @@ The following pattern will not match:
 
 We may be able to change this in future.
 
-The case of empty arrays is interesting. Consider this event:
+The case of empty arrays is interesting, both in Patterns and Events. Consider this event:
 
 ```json
 { "a": [] }
@@ -122,6 +122,16 @@ I.e., only the first of the two sample patterns below matches.
 ```
 This makes sense in the context of the leaf-node semantics; there
 really is no value for the `"a"` field.
+
+In Patterns, the following never matches any Event:
+
+```json
+{ "a": [] }
+```
+
+Once again, there is nothing in the array of candidate values in the Pattern that can match any value of an `"a"`
+field in an Event.
+
 
 
 ### Anything-But Pattern

--- a/core_matcher.go
+++ b/core_matcher.go
@@ -80,7 +80,6 @@ func (m *coreMatcher) addPattern(x X, patternJSON string) error {
 	// combo.
 	states := []*fieldMatcher{currentFields.state}
 	for _, field := range patternFields {
-
 		// if the field has no values, this is a no-op
 		if len(field.vals) == 0 {
 			continue

--- a/core_matcher.go
+++ b/core_matcher.go
@@ -80,6 +80,12 @@ func (m *coreMatcher) addPattern(x X, patternJSON string) error {
 	// combo.
 	states := []*fieldMatcher{currentFields.state}
 	for _, field := range patternFields {
+
+		// if the field has no values, this is a no-op
+		if len(field.vals) == 0 {
+			continue
+		}
+
 		var nextStates []*fieldMatcher
 
 		// separate handling for field exists:true/false and regular field name/val matches. Since the exists

--- a/pattern_test.go
+++ b/pattern_test.go
@@ -41,6 +41,60 @@ func TestPatternErrorHandling(t *testing.T) {
 	}
 }
 
+// test that adding an empty pattern doesn't screw anything up
+func TestEmptyValueArray(t *testing.T) {
+	var err error
+	empties := []string{
+		`{"data": {"field": []}}`,
+		`{"data": {"field": [], "field2": [23]}}`,
+		`{"data": {"field2": [], "field": [23]}}`,
+	}
+	wanted := map[string][]X{
+		`{"data": {"field": 23}}`:  {empties[2]},
+		`{"data": {"field2": 23}}`: {empties[1]},
+		`{"data": {"field": []}}`:  {},
+	}
+	cm := newCoreMatcher()
+	defer func() {
+		if r := recover(); r != nil {
+			t.Errorf("addPattern panicked")
+		}
+	}()
+	for _, empty := range empties {
+		err = cm.addPattern(empty, empty)
+		if err != nil {
+			t.Error("addPattern: " + err.Error())
+		}
+	}
+
+	for want, _ := range wanted {
+		matches, err := cm.matchesForJSONEvent([]byte(want))
+		if err != nil {
+			t.Errorf("m4je err on %s", want)
+		}
+		checkXEqual(wanted[want], matches, t)
+	}
+}
+func checkXEqual(x1s []X, x2s []X, t *testing.T) {
+	x2size := len(x2s)
+	for _, x1 := range x1s {
+		count := 0
+		for _, x2 := range x2s {
+			if x1 == x2 {
+				count++
+			}
+		}
+		if count != 1 {
+			t.Errorf("for %s in X1, %d", x1, count)
+		} else {
+			x2size--
+		}
+	}
+	if x2size != 0 {
+		t.Error("Extra elements in X2")
+	}
+}
+
 func TestPatternFromJSON(t *testing.T) {
 	bads := []string{
 		`x`,

--- a/pattern_test.go
+++ b/pattern_test.go
@@ -67,15 +67,16 @@ func TestEmptyValueArray(t *testing.T) {
 		}
 	}
 
-	for want, _ := range wanted {
+	for want := range wanted {
 		matches, err := cm.matchesForJSONEvent([]byte(want))
 		if err != nil {
 			t.Errorf("m4je err on %s", want)
 		}
-		checkXEqual(wanted[want], matches, t)
+		checkXEqual(t, wanted[want], matches)
 	}
 }
-func checkXEqual(x1s []X, x2s []X, t *testing.T) {
+func checkXEqual(t *testing.T, x1s []X, x2s []X) {
+	t.Helper()
 	x2size := len(x2s)
 	for _, x1 := range x1s {
 		count := 0

--- a/small_table_test.go
+++ b/small_table_test.go
@@ -176,7 +176,7 @@ func TestFuzzPack(t *testing.T) {
 func fuzzPack(t *testing.T, seed int64) {
 	t.Helper()
 
-	rand.Seed(seed)
+	rand.New(rand.NewSource(seed))
 	var used [byteCeiling]bool
 	var unpacked unpackedTable[*dfaStep]
 

--- a/value_matcher_test.go
+++ b/value_matcher_test.go
@@ -196,7 +196,7 @@ func TestOverlappingValues(t *testing.T) {
 }
 
 func TestFuzzValueMatcher(t *testing.T) {
-	rand.Seed(98543)
+	rand.New(rand.NewSource(98543))
 	m := newCoreMatcher()
 	var pNames []X
 	bytes := "abcdefghijklmnopqrstuvwxyz"
@@ -268,7 +268,7 @@ func TestFuzzValueMatcher(t *testing.T) {
 }
 
 func TestFuzzWithNumbers(t *testing.T) {
-	rand.Seed(98543)
+	rand.New(rand.NewSource(98543))
 	m := newCoreMatcher()
 	var pNames []X
 	used := make(map[X]bool)


### PR DESCRIPTION
The problem was that `{"data": {"field": []}}`, which is syntactically valid, would make `addPattern` blow up.  Which at one level is sane because it can't match anything, but on the other hand if you're generating Patterns it would be easy to write code to "match any of the elements of my array `PartNumbers`" and if `PartNumbers` was empty you'd get this kind of pattern and while it couldn't match anything, that would be the expected correct behavior.

The reason for excluding that particular message in the gosec linter is that the linter wants the crypto/rand as opposed to math/rand, but we want to retain the use of a fixed seed for the random number generator for testing/debugging purposes, and crypto/rand doesn't seem to support that and also is slower.