### PR TITLE
addresses issue #188

### DIFF
--- a/cl2_test.go
+++ b/cl2_test.go
@@ -187,20 +187,20 @@ func TestRulerCl2(t *testing.T) {
 
 	// initial run to stabilize memory
 	bm := newBenchmarker()
-	bm.addRules(exactRules, exactMatches)
+	bm.addRules(exactRules, exactMatches, false)
 
 	bm.run(t, lines)
 
 	bm = newBenchmarker()
-	bm.addRules(exactRules, exactMatches)
+	bm.addRules(exactRules, exactMatches, true)
 	fmt.Printf("EXACT events/sec: %.1f\n", bm.run(t, lines))
 
 	bm = newBenchmarker()
-	bm.addRules(prefixRules, prefixMatches)
+	bm.addRules(prefixRules, prefixMatches, true)
 	fmt.Printf("PREFIX events/sec: %.1f\n", bm.run(t, lines))
 
 	bm = newBenchmarker()
-	bm.addRules(anythingButRules, anythingButMatches)
+	bm.addRules(anythingButRules, anythingButMatches, true)
 	fmt.Printf("ANYTHING-BUT events/sec: %.1f\n", bm.run(t, lines))
 }
 
@@ -214,13 +214,15 @@ func newBenchmarker() *benchmarker {
 	return &benchmarker{q: q, wanted: make(map[X]int)}
 }
 
-func (bm *benchmarker) addRules(rules []string, wanted []int) {
+func (bm *benchmarker) addRules(rules []string, wanted []int, report bool) {
 	for i, rule := range rules {
 		rname := fmt.Sprintf("r%d", i)
 		_ = bm.q.AddPattern(rname, rule)
 		bm.wanted[rname] = wanted[i]
 	}
-	fmt.Println(matcherStats(bm.q.matcher.(*coreMatcher)))
+	if report {
+		fmt.Println(matcherStats(bm.q.matcher.(*coreMatcher)))
+	}
 }
 
 func (bm *benchmarker) run(t *testing.T, events [][]byte) float64 {

--- a/core_matcher.go
+++ b/core_matcher.go
@@ -129,7 +129,7 @@ func (m *coreMatcher) deletePatterns(_ X) error {
 // matchesForJSONEvent calls the flattener to pull the fields out of the event and
 // hands over to MatchesForFields
 // This is a leftover from previous times, is only used by tests, but it's used by a *lot*
-// so removing it would require a lot of tedious work
+// and it's a convenient API for testing.
 func (m *coreMatcher) matchesForJSONEvent(event []byte) ([]X, error) {
 	fields, err := newJSONFlattener().Flatten(event, m.getSegmentsTreeTracker())
 	if err != nil {

--- a/core_matcher.go
+++ b/core_matcher.go
@@ -181,8 +181,8 @@ func (m *coreMatcher) matchesForFields(fields []Field) ([]X, error) {
 	// pre-allocate a pair of buffers that will be used several levels down the call stack for efficiently
 	// transversing NFAs
 	bufs := &bufpair{
-		buf1: make([]*faState, 0, 3072),
-		buf2: make([]*faState, 0, 3072),
+		buf1: make([]*faState, 0),
+		buf2: make([]*faState, 0),
 	}
 
 	// for each of the fields, we'll try to match the automaton start state to that field - the tryToMatch

--- a/field_matcher.go
+++ b/field_matcher.go
@@ -6,7 +6,7 @@ import (
 
 // fieldMatcher represents a state in the matching automaton, which matches field names and dispatches to
 // valueMatcher to complete matching of field values.
-// the fields that hold state are segregated in updateable so they can be replaced atomically and make the coreMatcher
+// the fields that hold state are segregated in updateable, so they can be replaced atomically and make the coreMatcher
 // thread-safe.
 type fieldMatcher struct {
 	updateable atomic.Value // always holds an *fmFields
@@ -112,7 +112,7 @@ func (m *fieldMatcher) addTransition(field *patternField, printer printer) []*fi
 	}
 	freshStart.transitions[field.path] = vm
 
-	// suppose I'm adding the first pattern to a matcher and it has "x": [1, 2]. In principle the branches on
+	// suppose I'm adding the first pattern to a matcher, and it has "x": [1, 2]. In principle the branches on
 	//  "x": 1 and "x": 2 could go to tne same next state. But we have to make a unique next state for each of them
 	//  because some future other pattern might have "x": [2, 3] and thus we need a separate branch to potentially
 	//  match two patterns on "x": 2 but not "x": 1. If you were optimizing the automaton for size you might detect

--- a/field_matcher.go
+++ b/field_matcher.go
@@ -144,12 +144,12 @@ func (m *fieldMatcher) addTransition(field *patternField, printer printer) []*fi
 // or nil if no transitions are possible.  An example of name/value that could produce multiple next states
 // would be if you had the pattern { "a": [ "foo" ] } and another pattern that matched any value with
 // a prefix of "f".
-func (m *fieldMatcher) transitionOn(field *Field) []*fieldMatcher {
+func (m *fieldMatcher) transitionOn(field *Field, bufs *bufpair) []*fieldMatcher {
 	// are there transitions on this field name?
 	valMatcher, ok := m.fields().transitions[string(field.Path)]
 	if !ok {
 		return nil
 	}
 
-	return valMatcher.transitionOn(field.Val)
+	return valMatcher.transitionOn(field.Val, bufs)
 }

--- a/nfa.go
+++ b/nfa.go
@@ -1,35 +1,81 @@
 package quamina
 
+import "fmt"
+
 // This groups the functions that traverse, merge, and debug Quamina's nondeterministic finite automata
 
-func traverseFA(table *smallTable, val []byte, transitions []*fieldMatcher) []*fieldMatcher {
-	return traverseOneFAStep(table, 0, val, transitions)
+// faState is used by the valueMatcher automaton - every step through the
+// automaton requires a smallTable and for some of them, taking the step means you've matched a value and can
+// transition to a new fieldMatcher, in which case the fieldTransitions slice will be non-nil
+type faState struct {
+	table            *smallTable
+	fieldTransitions []*fieldMatcher
 }
 
-func traverseOneFAStep(table *smallTable, index int, val []byte, transitions []*fieldMatcher) []*fieldMatcher {
-	var utf8Byte byte
-	switch {
-	case index < len(val):
-		utf8Byte = val[index]
-	case index == len(val):
-		utf8Byte = valueTerminator
-	default:
-		return transitions
+// struct wrapper to make this comparable to help with pack/unpack
+type faNext struct {
+	states []*faState
+}
+
+type transmap struct {
+	set map[*fieldMatcher]bool
+}
+
+func (tm *transmap) add(fms []*fieldMatcher) {
+	for _, fm := range fms {
+		tm.set[fm] = true
 	}
-	nextSteps := table.step(utf8Byte)
-	if nextSteps == nil {
-		return transitions
+}
+
+func (tm *transmap) all() []*fieldMatcher {
+	var all []*fieldMatcher
+	for fm := range tm.set {
+		all = append(all, fm)
 	}
-	index++
-	// 1. Note no effort to traverse multiple next-steps in parallel. The traversal compute is tiny and the
-	//    necessary concurrency apparatus would almost certainly outweigh it
-	// 2. TODO: It would probably be better to implement this iteratively rather than recursively.
-	//    The recursion will potentially go as deep as the val argument is long.
-	for _, nextStep := range nextSteps.steps {
-		transitions = append(transitions, nextStep.fieldTransitions...)
-		transitions = traverseOneFAStep(nextStep.table, index, val, transitions)
+	return all
+}
+
+func traverseFA(table *smallTable, val []byte, transitions []*fieldMatcher, bufs *bufpair) []*fieldMatcher {
+	currentStates := bufs.buf1
+	currentStates = append(currentStates, &faState{table: table})
+	nextStates := bufs.buf2
+
+	// a lot of the transitions stuff is going to be empty, but on the other hand
+	// a * entry with a transition could end up getting added a lot.
+	newTransitions := &transmap{set: make(map[*fieldMatcher]bool, len(transitions))}
+	newTransitions.add(transitions)
+	stepResult := &stepOut{}
+	for index := 0; len(currentStates) != 0 && index <= len(val); index++ {
+		var utf8Byte byte
+		if index < len(val) {
+			utf8Byte = val[index]
+		} else {
+			utf8Byte = valueTerminator
+		}
+		for _, state := range currentStates {
+			state.table.step(utf8Byte, stepResult)
+			for _, nextStep := range stepResult.steps {
+				newTransitions.add(nextStep.fieldTransitions)
+				nextStates = append(nextStates, nextStep)
+			}
+			for _, nextStep := range stepResult.epsilon {
+				newTransitions.add(nextStep.fieldTransitions)
+				nextStates = append(nextStates, nextStep)
+			}
+		}
+		// re-use these
+		swapStates := currentStates
+		currentStates = nextStates
+		nextStates = swapStates[:0]
 	}
-	return transitions
+	bufs.buf1 = currentStates[:0]
+	bufs.buf2 = nextStates[:0]
+	return newTransitions.all()
+}
+
+type faStepKey struct {
+	step1 *faState
+	step2 *faState
 }
 
 // mergeFAs compute the union of two valueMatch automata.  If you look up the textbook theory about this,
@@ -39,21 +85,13 @@ func traverseOneFAStep(table *smallTable, index int, val []byte, transitions []*
 // minimal or even avoids being wasteful.
 // INVARIANT: neither argument is nil
 // INVARIANT: To be thread-safe, no existing table can be updated except when we're building it
-
-type faStepKey struct {
-	step1 *faState
-	step2 *faState
-}
-
-func mergeFAs(table1, table2 *smallTable) *smallTable {
+func mergeFAs(table1, table2 *smallTable, printer printer) *smallTable {
 	state1 := &faState{table: table1}
 	state2 := &faState{table: table2}
-	return mergeFAStates(state1, state2, make(map[faStepKey]*faState)).table
+	return mergeFAStates(state1, state2, make(map[faStepKey]*faState), printer).table
 }
 
-// TODO: maybe memoize these based on the string of characters you matched to get here?
-// TODO: recursion seems way too deep
-func mergeFAStates(state1, state2 *faState, keyMemo map[faStepKey]*faState) *faState {
+func mergeFAStates(state1, state2 *faState, keyMemo map[faStepKey]*faState, printer printer) *faState {
 	var combined *faState
 	mKey := faStepKey{state1, state2}
 	combined, ok := keyMemo[mKey]
@@ -65,7 +103,13 @@ func mergeFAStates(state1, state2 *faState, keyMemo map[faStepKey]*faState) *faS
 
 	fieldTransitions := append(state1.fieldTransitions, state2.fieldTransitions...)
 	combined = &faState{table: newTable, fieldTransitions: fieldTransitions}
-	//DEBUG combined.table.label = fmt.Sprintf("(%s ∎ %s)", state1.table.label, state2.table.label)
+
+	pretty, ok := printer.(*prettyPrinter)
+	if ok {
+		printer.labelTable(combined.table, fmt.Sprintf("%d∎%d", pretty.tableSerial(state1.table),
+			pretty.tableSerial(state2.table)))
+	}
+
 	keyMemo[mKey] = combined
 	u1 := unpackTable(state1.table)
 	u2 := unpackTable(state2.table)
@@ -74,34 +118,28 @@ func mergeFAStates(state1, state2 *faState, keyMemo map[faStepKey]*faState) *faS
 	for i, next1 := range u1 {
 		next2 := u2[i]
 		switch {
-		case next1 == nil && next2 == nil:
-			uComb[i] = nil
+		case next1 == next2:
+			uComb[i] = next1
 		case next1 != nil && next2 == nil:
 			uComb[i] = u1[i]
 		case next1 == nil && next2 != nil:
 			uComb[i] = u2[i]
 		case next1 != nil && next2 != nil:
-			//fmt.Printf("MERGE %s & %s i=%d d=%d: ", next1, next2, i, depth)
-			if next1 == next2 {
-				//	fmt.Println("n1 == n2")
-				uComb[i] = next1
-			} else if i > 0 && next1 == u1[i-1] && next2 == u2[i-1] {
+			if i > 0 && next1 == u1[i-1] && next2 == u2[i-1] {
 				uComb[i] = uComb[i-1]
-				//	fmt.Printf("SEQ %s\n", uComb[i].steps[0].table.shortDump())
 			} else {
-				//	fmt.Println("RECURSE!")
 				var comboNext []*faState
-				for _, nextStep1 := range next1.steps {
-					for _, nextStep2 := range next2.steps {
-						comboNext = append(comboNext, mergeFAStates(nextStep1, nextStep2, keyMemo))
+				for _, nextStep1 := range next1.states {
+					for _, nextStep2 := range next2.states {
+						comboNext = append(comboNext, mergeFAStates(nextStep1, nextStep2, keyMemo, printer))
 					}
 				}
-				uComb[i] = &faNext{steps: comboNext}
-				//DEBUG uComb[i].serial = *serial
+				uComb[i] = &faNext{states: comboNext}
 			}
 		}
 	}
 	combined.table.pack(&uComb)
+	combined.table.epsilon = append(state1.table.epsilon, state2.table.epsilon...)
 
 	return combined
 }

--- a/nfa_test.go
+++ b/nfa_test.go
@@ -58,7 +58,7 @@ func TestFocusedMerge(t *testing.T) {
 
 	for _, shellStyle := range shellStyles {
 		str := `"` + shellStyle + `"`
-		automaton, matcher := makeShellStyleAutomaton([]byte(str), &nullPrinter{})
+		automaton, matcher := makeShellStyleFA([]byte(str), &nullPrinter{})
 		automata = append(automata, automaton)
 		matchers = append(matchers, matcher)
 	}
@@ -71,7 +71,7 @@ func TestFocusedMerge(t *testing.T) {
 
 	merged := newSmallTable()
 	for _, automaton := range automata {
-		merged = mergeFAs(merged, automaton)
+		merged = mergeFAs(merged, automaton, sharedNullPrinter)
 
 		s := statsAccum{
 			fmVisited: make(map[*fieldMatcher]bool),
@@ -80,28 +80,5 @@ func TestFocusedMerge(t *testing.T) {
 		}
 		faStats(merged, &s)
 		fmt.Println(s.stStats())
-	}
-}
-
-func TestNFABasics(t *testing.T) {
-	aFoo, fFoo := makeStringFA([]byte("foo"), nil)
-	var matches []*fieldMatcher
-
-	matches = traverseOneFAStep(aFoo, 0, []byte("foo"), nil)
-	if len(matches) != 1 || matches[0] != fFoo {
-		t.Error("ouch no foo")
-	}
-	matches = traverseOneFAStep(aFoo, 0, []byte("foot"), nil)
-	if len(matches) != 0 {
-		t.Error("ouch yes foot")
-	}
-
-	aNotFoot, fNotFoot := makeMultiAnythingButFA([][]byte{[]byte("foot")})
-	notFeet := []string{"foo", "footy", "afoot", "xyz"}
-	for _, notFoot := range notFeet {
-		matches = traverseOneFAStep(aNotFoot, 0, []byte(notFoot), nil)
-		if len(matches) != 1 || matches[0] != fNotFoot {
-			t.Error("!foot miss: " + notFoot)
-		}
 	}
 }

--- a/prettyprinter_test.go
+++ b/prettyprinter_test.go
@@ -6,21 +6,21 @@ import (
 
 func TestPP(t *testing.T) {
 	pp := newPrettyPrinter(1)
-	table, _ := makeShellStyleAutomaton([]byte(`"x*9"`), pp)
+	table, _ := makeShellStyleFA([]byte(`"x*9"`), pp)
 	pp.labelTable(table, "START HERE")
-	wanted := ` 758 [START HERE] '"' → [910 on " at 0]
- 910 [on " at 0] 'x' → [821 gS at 2]
- 821 [gS at 2] '9' → [551 gX on 9 at 3] / ★ → [821 gS at 2]
- 551 [gX on 9 at 3] '"' → [937 on " at 4] / '9' → [551 gX on 9 at 3] / ★ → [821 gS at 2]
- 937 [on " at 4] '9' → [551 gX on 9 at 3] / 'ℵ' → [820 last step at 5] / ★ → [821 gS at 2]
- 820 [last step at 5]  [1 transition(s)]
+	wanted := ` 758[START HERE] '"' → 910[on " at 0]
+ 910[on " at 0] 'x' → 821[gS at 2]
+ 821[gS at 2] ε → 821[gS at 2] / '9' → 551[gX on 9 at 3]
+ 551[gX on 9 at 3] '"' → 937[on " at 4]
+ 937[on " at 4] 'ℵ' → 820[last step at 5]
+ 820[last step at 5]  [1 transition(s)]
 `
 	s := pp.printNFA(table)
 	if s != wanted {
 		t.Errorf("LONG: wanted\n<%s>\ngot\n<%s>\n", wanted, s)
 	}
-	if pp.shortPrintNFA(table) != "758-START HERE" {
-		t.Errorf("SHORT: wanted <%s> got <%s>\n", "758-START HERE", pp.shortPrintNFA(table))
+	if pp.shortPrintNFA(table) != "758[START HERE]" {
+		t.Errorf("SHORT: wanted <%s> got <%s>\n", "758[START HERE]", pp.shortPrintNFA(table))
 	}
 }
 

--- a/shell_style.go
+++ b/shell_style.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 )
 
+// TODO: remove the limitation of only one "*" in the pattern
+
 // readShellStyleSpecial parses a shellStyle object in a Pattern
 func readShellStyleSpecial(pb *patternBuild, valsIn []typedVal) (pathVals []typedVal, err error) {
 	t, err := pb.jd.Token()
@@ -50,74 +52,49 @@ func readShellStyleSpecial(pb *patternBuild, valsIn []typedVal) (pathVals []type
 	return
 }
 
-// makeShellStyleAutomaton - recognize a "-delimited string containing one '*' glob.
-func makeShellStyleAutomaton(val []byte, printer printer) (start *smallTable, nextField *fieldMatcher) {
+// makeShellStyleFA does what it says.  It is precisely equivalent to a regex with the only operator
+// being a single ".*". Once we've implemented regular expressions we can use that to more or less eliminate this
+func makeShellStyleFA(val []byte, printer printer) (start *smallTable, nextField *fieldMatcher) {
 	table := newSmallTable()
 	start = table
 	nextField = newFieldMatcher()
 
 	// for each byte in the pattern
-	var globStep *faState = nil
-	var globExitStep *faState = nil
-	var globExitByte byte
-	i := 0
-	for i < len(val) {
-		ch := val[i]
+	valIndex := 0
+	for valIndex < len(val) {
+		ch := val[valIndex]
 		if ch == '*' {
 			// special-case handling for string ending in '*"' - transition to field match on any character.
-			//  we know the trailing '"' will be there because of JSON syntax.
-			if i == len(val)-2 {
-				step := &faState{table: newSmallTable(), fieldTransitions: []*fieldMatcher{nextField}}
-				table.setDefault(&faNext{steps: []*faState{step}})
-				printer.labelTable(table, fmt.Sprintf("prefix escape at %d", i))
+			// we know the trailing '"' will be there because of JSON syntax.  We could use an epsilon state
+			// but then the matcher will process through all the rest of the bytes, when it doesn't need to
+			if valIndex == len(val)-2 {
+				step := &faState{
+					table:            newSmallTable(),
+					fieldTransitions: []*fieldMatcher{nextField},
+				}
+				table.epsilon = []*faState{step}
+				printer.labelTable(table, fmt.Sprintf("prefix escape at %d", valIndex))
 				return
 			}
+			globStep := &faState{table: table}
+			printer.labelTable(table, fmt.Sprintf("gS at %d", valIndex))
+			table.epsilon = []*faState{globStep}
 
-			// loop back on everything
-			globStep = &faState{table: table}
-			printer.labelTable(table, fmt.Sprintf("gS at %d", i))
-			table.setDefault(&faNext{steps: []*faState{globStep}})
-
-			// escape the glob on the next char from the pattern - remember the byte and the state escaped to
-			i++
-			globExitByte = val[i]
-			globExitStep = &faState{table: newSmallTable()}
-			printer.labelTable(globExitStep.table, fmt.Sprintf("gX on %c at %d", val[i], i))
-			// escape the glob
-			table.addByteStep(globExitByte, &faNext{steps: []*faState{globExitStep}})
-			table = globExitStep.table
+			valIndex++
+			globNext := &faState{table: newSmallTable()}
+			printer.labelTable(globNext.table, fmt.Sprintf("gX on %c at %d", val[valIndex], valIndex))
+			table.addByteStep(val[valIndex], &faNext{states: []*faState{globNext}})
+			table = globNext.table
 		} else {
 			nextStep := &faState{table: newSmallTable()}
-			printer.labelTable(nextStep.table, fmt.Sprintf("on %c at %d", val[i], i))
-
-			// we're going to move forward on 'ch'.  On anything else, we leave it at nil or - if we've passed
-			//  a glob, loop back to the glob stae.  if 'ch' is also the glob exit byte, also put in a transfer
-			//  back to the glob exist state
-			if globExitStep != nil {
-				table.setDefault(&faNext{steps: []*faState{globStep}})
-				if ch == globExitByte {
-					table.addByteStep(ch, &faNext{steps: []*faState{globExitStep, nextStep}})
-				} else {
-					table.addByteStep(globExitByte, &faNext{steps: []*faState{globExitStep}})
-					table.addByteStep(ch, &faNext{steps: []*faState{nextStep}})
-				}
-			} else {
-				table.addByteStep(ch, &faNext{steps: []*faState{nextStep}})
-			}
+			printer.labelTable(nextStep.table, fmt.Sprintf("on %c at %d", val[valIndex], valIndex))
+			table.addByteStep(ch, &faNext{states: []*faState{nextStep}})
 			table = nextStep.table
 		}
-		i++
+		valIndex++
 	}
-
 	lastStep := &faState{table: newSmallTable(), fieldTransitions: []*fieldMatcher{nextField}}
-	printer.labelTable(lastStep.table, fmt.Sprintf("last step at %d", i))
-	if globExitStep != nil {
-		table.setDefault(&faNext{steps: []*faState{globStep}})
-		table.addByteStep(globExitByte, &faNext{steps: []*faState{globExitStep}})
-		table.addByteStep(valueTerminator, &faNext{steps: []*faState{lastStep}})
-	} else {
-		table.addByteStep(valueTerminator, &faNext{steps: []*faState{lastStep}})
-	}
-	// fmt.Printf("new for [%s]: %s\n", string(val), printer.printNFA(start))
+	printer.labelTable(lastStep.table, fmt.Sprintf("last step at %d", valIndex))
+	table.addByteStep(valueTerminator, &faNext{states: []*faState{lastStep}})
 	return
 }

--- a/small_table_test.go
+++ b/small_table_test.go
@@ -43,7 +43,7 @@ func TestUnpack(t *testing.T) {
 		table:            st1,
 		fieldTransitions: nil,
 	}
-	nextStep := faNext{steps: []*faState{&nextState}}
+	nextStep := faNext{states: []*faState{&nextState}}
 
 	st := smallTable{
 		ceilings: []uint8{2, 3, byte(byteCeiling)},
@@ -127,7 +127,7 @@ func fuzzPack(t *testing.T, seed int64) {
 		if c != packed.ceilings[i] {
 			t.Errorf("seed %d ceilings differ at %d wanted %d got %d", seed, i, c, packed.ceilings[i])
 		}
-		if packed.steps[i] != rePacked.steps[i] {
+		if packed.states[i] != rePacked.states[i] {
 			t.Errorf("seed %d ssteps differ at %d", seed, i)
 		}
 	}

--- a/value_matcher.go
+++ b/value_matcher.go
@@ -29,7 +29,6 @@ type vmFields struct {
 	startTable          *smallTable
 	singletonMatch      []byte
 	singletonTransition *fieldMatcher
-	buffers             bufpair
 }
 
 func (m *valueMatcher) fields() *vmFields {
@@ -52,7 +51,7 @@ func newValueMatcher() *valueMatcher {
 	return &vm
 }
 
-func (m *valueMatcher) transitionOn(val []byte) []*fieldMatcher {
+func (m *valueMatcher) transitionOn(val []byte, bufs *bufpair) []*fieldMatcher {
 	var transitions []*fieldMatcher
 
 	fields := m.fields()
@@ -69,7 +68,7 @@ func (m *valueMatcher) transitionOn(val []byte) []*fieldMatcher {
 		return transitions
 
 	case fields.startTable != nil:
-		return traverseFA(fields.startTable, val, transitions, &fields.buffers)
+		return traverseFA(fields.startTable, val, transitions, bufs)
 
 	default:
 		// no FA, no singleton, nothing to do, this probably can't happen because a flattener

--- a/value_matcher_test.go
+++ b/value_matcher_test.go
@@ -41,7 +41,7 @@ func addInvalid(t *testing.T, before []typedVal) {
 
 func TestNoOpTransition(t *testing.T) {
 	vm := newValueMatcher()
-	tr := vm.transitionOn([]byte("foo"))
+	tr := vm.transitionOn([]byte("foo"), &bufpair{})
 	if len(tr) != 0 {
 		t.Error("matched on empty valuematcher")
 	}
@@ -57,7 +57,7 @@ func TestAddTransition(t *testing.T) {
 	if t1 == nil {
 		t.Error("nil addTrans")
 	}
-	t1x := m.transitionOn([]byte("one"))
+	t1x := m.transitionOn([]byte("one"), &bufpair{})
 	if len(t1x) != 1 || t1x[0] != t1 {
 		t.Error("Retrieve failed")
 	}
@@ -73,11 +73,11 @@ func TestAddTransition(t *testing.T) {
 	}
 	t2 := m.addTransition(v2, &nullPrinter{})
 
-	t2x := m.transitionOn([]byte("two"))
+	t2x := m.transitionOn([]byte("two"), &bufpair{})
 	if len(t2x) != 1 || t2x[0] != t2 {
 		t.Error("trans failed T2")
 	}
-	t1x = m.transitionOn([]byte("one"))
+	t1x = m.transitionOn([]byte("one"), &bufpair{})
 	if len(t1x) != 1 || t1x[0] != t1 {
 		t.Error("Retrieve failed")
 	}
@@ -86,15 +86,15 @@ func TestAddTransition(t *testing.T) {
 		val:   "three",
 	}
 	t3 := m.addTransition(v3, &nullPrinter{})
-	t3x := m.transitionOn([]byte("three"))
+	t3x := m.transitionOn([]byte("three"), &bufpair{})
 	if len(t3x) != 1 || t3x[0] != t3 {
 		t.Error("Match failed T3")
 	}
-	t2x = m.transitionOn([]byte("two"))
+	t2x = m.transitionOn([]byte("two"), &bufpair{})
 	if len(t2x) != 1 || t2x[0] != t2 {
 		t.Error("trans failed T2")
 	}
-	t1x = m.transitionOn([]byte("one"))
+	t1x = m.transitionOn([]byte("one"), &bufpair{})
 	if len(t1x) != 1 || t1x[0] != t1 {
 		t.Error("Retrieve failed")
 	}


### PR DESCRIPTION
prevent state explosions with epsilon transitions

The introduction of proper NFA epsilon transitions - see https://swtch.com/~rsc/regexp/regexp1.html - totally fixed this problem. The most dramatic illustration is line 96 of shell_style_test.go. Previously, you could only use 20 or so shell_style patterns before an O(2**N) explosion leading to millions of states. Now you can add all 12K in the test file.  The `addPattern()` runs almost instantly, although matching slows down, a fair trade-off.

Once this is landed, we can start implementing all the cool stuff that was-ruler has without worry about exploding NFAs.