### PR TITLE
kaizen: add analyzer, misc cleanup

### DIFF
--- a/benchmarks_test.go
+++ b/benchmarks_test.go
@@ -86,8 +86,6 @@ func TestCRANLEIGH(t *testing.T) {
 	}
 }
 
-// - restore when we've got multi-glob working
-/*
 func TestMySoftwareHatesMe(t *testing.T) {
 	line := `{ "type": "Feature", "properties": { "STREET": "BELVEDERE" }  }`
 	m := newCoreMatcher()
@@ -97,7 +95,7 @@ func TestMySoftwareHatesMe(t *testing.T) {
 	if m.addPattern("EEE", EEEpat) != nil {
 		t.Error("Huh add?")
 	}
-	matches, err := m.MatchesForEvent([]byte(line))
+	matches, _ := m.matchesForJSONEvent([]byte(line))
 	if len(matches) != 1 || matches[0] != "EEE" {
 		t.Error("Failed to match EEE")
 	}
@@ -106,10 +104,7 @@ func TestMySoftwareHatesMe(t *testing.T) {
 	_ = m.addPattern("B", Bpat)
 	_ = m.addPattern("EEE", EEEpat)
 
-	matches, err = m.MatchesForEvent([]byte(line))
-	if err != nil {
-		t.Error("Huh? " + err.Error())
-	}
+	matches, _ = m.matchesForJSONEvent([]byte(line))
 	if !containsX(matches, "B") {
 		t.Error("no match for B")
 	}
@@ -117,7 +112,6 @@ func TestMySoftwareHatesMe(t *testing.T) {
 		t.Error("no match for EEE")
 	}
 }
-*/
 
 // exercise shellstyle matching a little, is much faster than TestCityLots because it's only working wth one field
 func TestBigShellStyle(t *testing.T) {
@@ -131,12 +125,10 @@ func TestBigShellStyle(t *testing.T) {
 		"V": 4322, "W": 4162, "X": 0, "Y": 721, "Z": 25,
 	}
 
-	/* - restore when we've got multi-glob working
 	funky := map[X]int{
 		`{"properties": {"STREET":[ {"shellstyle": "N*P*"} ] } }`:    927,
 		`{"properties": {"STREET":[ {"shellstyle": "*E*E*E*"} ] } }`: 1212,
 	}
-	*/
 
 	for letter := range wanted {
 		pat := fmt.Sprintf(`{"properties": {"STREET":[ {"shellstyle": "%s*"} ] } }`, letter)
@@ -146,14 +138,12 @@ func TestBigShellStyle(t *testing.T) {
 		}
 	}
 
-	/*
-		for funk := range funky {
-			err := m.addPattern(funk, funk.(string))
-			if err != nil {
-				t.Errorf("err on %s: %s", funk, err.Error())
-			}
+	for funk := range funky {
+		err := m.addPattern(funk, funk.(string))
+		if err != nil {
+			t.Errorf("err on %s: %s", funk, err.Error())
 		}
-	*/
+	}
 	fmt.Println(matcherStats(m))
 
 	lCounts := make(map[X]int)
@@ -187,14 +177,11 @@ func TestBigShellStyle(t *testing.T) {
 			t.Errorf("for %s wanted %d got %d", k, wc, lCounts[k])
 		}
 	}
-	/*
-		for k, wc := range funky {
-			if lCounts[k] != wc {
-				t.Errorf("for %s wanted %d got %d", k, wc, lCounts[k])
-			}
+	for k, wc := range funky {
+		if lCounts[k] != wc {
+			t.Errorf("for %s wanted %d got %d", k, wc, lCounts[k])
 		}
-
-	*/
+	}
 }
 
 // TestPatternAddition adds a whole lot of string-only rules as fast as possible  The profiler says that the

--- a/cl2_test.go
+++ b/cl2_test.go
@@ -248,13 +248,16 @@ func newBenchmarker() *benchmarker {
 }
 
 func (bm *benchmarker) addRules(rules []string, wanted []int, report bool) {
+	cm := bm.q.matcher.(*coreMatcher)
 	for i, rule := range rules {
 		rname := fmt.Sprintf("r%d", i)
 		_ = bm.q.AddPattern(rname, rule)
 		bm.wanted[rname] = wanted[i]
 	}
+	cm.analyze()
 	if report {
-		fmt.Println(matcherStats(bm.q.matcher.(*coreMatcher)))
+		fmt.Println(matcherStats(cm))
+		fmt.Printf("MaxParallel: %d\n", cm.fields().nfaMeta.maxOutDegree)
 	}
 }
 

--- a/field_matcher.go
+++ b/field_matcher.go
@@ -35,6 +35,18 @@ func (m *fieldMatcher) update(fields *fmFields) {
 	m.updateable.Store(fields)
 }
 
+func (m *fieldMatcher) gatherMetadata(meta *nfaMetadata) {
+	for _, vm := range m.fields().transitions {
+		vm.gatherMetadata(meta)
+	}
+	for _, fm := range m.fields().existsTrue {
+		fm.gatherMetadata(meta)
+	}
+	for _, fm := range m.fields().existsFalse {
+		fm.gatherMetadata(meta)
+	}
+}
+
 func (m *fieldMatcher) addMatch(x X) {
 	current := m.fields()
 	newFields := &fmFields{

--- a/prettyprinter.go
+++ b/prettyprinter.go
@@ -157,8 +157,6 @@ func (pp *prettyPrinter) nextString(n *faNext) string {
 func branchChar(b byte) string {
 	switch b {
 	// TODO: Figure out how to test commented-out cases
-	case 0:
-		return "∅"
 	case valueTerminator:
 		return "ℵ"
 	default:

--- a/shell_style_test.go
+++ b/shell_style_test.go
@@ -110,11 +110,11 @@ func TestWildCardRuler(t *testing.T) {
 		t.Error("Missed on r2")
 	}
 	matches, _ = cm.matchesForJSONEvent([]byte("{\"b\" : \"dexeff\"}"))
-	if len(matches) != 2 || (!containsX(matches, "r2")) || !containsX(matches, "r3") {
+	if len(matches) != 2 || (!containsX(matches, "r2", "r3")) {
 		t.Error("Missed on r2/r3")
 	}
 	matches, _ = cm.matchesForJSONEvent([]byte("{\"c\" : \"xyzzz\"}"))
-	if len(matches) != 2 || (!containsX(matches, "r4")) || !containsX(matches, "r5") {
+	if len(matches) != 2 || (!containsX(matches, "r4", "r5")) {
 		t.Error("Missed on r4/r5")
 	}
 	matches, _ = cm.matchesForJSONEvent([]byte("{\"d\" : \"12345\"}"))
@@ -174,7 +174,12 @@ func TestShellStyleBuildTime(t *testing.T) {
 			t.Error("AddP: " + err.Error())
 		}
 	}
-	fmt.Println(matcherStats(q.matcher.(*coreMatcher)))
+	cm := q.matcher.(*coreMatcher)
+
+	fmt.Println(matcherStats(cm))
+	cm.analyze()
+	fmt.Printf("MaxP: %d\n", cm.fields().nfaMeta.maxOutDegree)
+
 	// make sure that all the words actually are matched
 	before := time.Now()
 	for _, word := range words {

--- a/small_table.go
+++ b/small_table.go
@@ -100,6 +100,20 @@ func makeSmallTable(defaultStep *faNext, indices []byte, steps []*faNext) *small
 	return &t
 }
 
+func (t *smallTable) gatherMetadata(meta *nfaMetadata) {
+	eps := len(t.epsilon)
+	for _, step := range t.steps {
+		if step != nil {
+			if (eps + len(step.states)) > meta.maxOutDegree {
+				meta.maxOutDegree = eps + len(step.states)
+			}
+			for _, state := range step.states {
+				state.table.gatherMetadata(meta)
+			}
+		}
+	}
+}
+
 // unpackedTable replicates the data in the smallTable ceilings and states arrays.  It's quite hard to
 // update the list structure in a smallTable, but trivial in an unpackedTable.  The idea is that to update
 // a smallTable you unpack it, update, then re-pack it.  Not gonna be the most efficient thing so at some future point…

--- a/value_matcher.go
+++ b/value_matcher.go
@@ -166,6 +166,13 @@ func (m *valueMatcher) addTransition(val typedVal, printer printer) *fieldMatche
 	return nextField
 }
 
+func (m *valueMatcher) gatherMetadata(meta *nfaMetadata) {
+	start := m.fields().startTable
+	if start != nil {
+		start.gatherMetadata(meta)
+	}
+}
+
 // TODO: make these simple FA builders iterative not recursive, this will recurse as deep as the longest string match
 
 func makePrefixFA(val []byte) (*smallTable, *fieldMatcher) {


### PR DESCRIPTION
This adds the function `analyze()` to coreMatcher.  It visits all of the fieldMatcher and valueMatcher states and gathers statistics (at the moment, just the maximum nondeterministic concurrency).  For the moment, this is strictly an (extremely useful) tool for developers trying to optimize NFA construction/traversal.

Its output could be used in practice to increase the performance of the pathological case illustrated by `TestShellStyleBuildTime()`, which slows down to <10K/second when you add 13K wildcard patterns, but that
particular optimization requires much more thinking.

No public API yet, but this could evolve into something similar to Ruler's `MachineComplexityEvaluator` public API although I'm not happy with the metric that API generates.

Also in this commit: Miscellaneous code cleanups including fixing a new lint problem detected by recent `golangci-lint`, and restoring tests that had been commented out because of the NFA state explosion.