### PR TITLE
chore: prefer atomic.Pointer to atomic.Value

### DIFF
--- a/core_matcher.go
+++ b/core_matcher.go
@@ -19,10 +19,10 @@ import (
 // There are two levels of concurrency here. First, the lock field in this struct must be held by any goroutine
 // that is executing addPattern(), i.e. only one thread may be updating the state machine at one time.
 // However, any number of goroutines may in parallel be executing matchesForFields while the addPattern
-// update is in progress. The updateable atomic.Value allows the addPattern thread to change the maps and
+// update is in progress. The updateable atomic.Pointer allows the addPattern thread to change the maps and
 // slices in the structure atomically with atomic.Load() while matchesForFields threads are reading them.
 type coreMatcher struct {
-	updateable atomic.Value // always holds a *coreFields
+	updateable atomic.Pointer[coreFields]
 	lock       sync.Mutex
 }
 
@@ -48,7 +48,7 @@ func newCoreMatcher() *coreMatcher {
 }
 
 func (m *coreMatcher) fields() *coreFields {
-	return m.updateable.Load().(*coreFields)
+	return m.updateable.Load()
 }
 
 // analyze traverses all the different per-field NFAs and gathers metadata that can be

--- a/field_matcher.go
+++ b/field_matcher.go
@@ -9,7 +9,7 @@ import (
 // the fields that hold state are segregated in updateable, so they can be replaced atomically and make the coreMatcher
 // thread-safe.
 type fieldMatcher struct {
-	updateable atomic.Value // always holds an *fmFields
+	updateable atomic.Pointer[fmFields]
 }
 
 // fmFields contains the updateable fields in fieldMatcher.
@@ -28,7 +28,7 @@ type fmFields struct {
 // fields / update / addExistsFalseFailure / addMatch exist to insulate callers from dealing with
 // the atomic Load/Store business
 func (m *fieldMatcher) fields() *fmFields {
-	return m.updateable.Load().(*fmFields)
+	return m.updateable.Load()
 }
 
 func (m *fieldMatcher) update(fields *fmFields) {

--- a/value_matcher.go
+++ b/value_matcher.go
@@ -21,9 +21,9 @@ type bufpair struct {
 // having a long chain of smallTables each with only one entry.
 // To allow for concurrent access between one thread running AddPattern and many
 // others running MatchesForEvent, the valueMatcher payload is stored in an
-// atomic.Value
+// atomic.Pointer
 type valueMatcher struct {
-	updateable atomic.Value // always contains *vmFields
+	updateable atomic.Pointer[vmFields]
 }
 type vmFields struct {
 	startTable          *smallTable
@@ -34,11 +34,11 @@ type vmFields struct {
 }
 
 func (m *valueMatcher) fields() *vmFields {
-	return m.updateable.Load().(*vmFields)
+	return m.updateable.Load()
 }
 
 func (m *valueMatcher) getFieldsForUpdate() *vmFields {
-	current := m.updateable.Load().(*vmFields)
+	current := m.updateable.Load()
 	freshState := *current // struct copy
 	return &freshState
 }


### PR DESCRIPTION
This improves the situation by closing down the api and enforcing the required type.
It also slightly reduces allocations and memory use and - at least on my system - improves benchmarking time for the whole system from 35.788s to 32.588s (but only one run each and 2 days apart...).