### PR TITLE
kaizen: Move to v1.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Quamina [welcomes contributions](CONTRIBUTING.md).
 
 ### Status
 
-This is version 1.3.0 of Quamina. In future, the API will be changed only additively.
+This is version 1.4.0 of Quamina. In future, the API will be changed only additively.
 
 Note that we have documented more APIs than are actually
 fully implemented, with the intent of showing direction.

--- a/numbits.go
+++ b/numbits.go
@@ -34,7 +34,7 @@ const MaxBytesInEncoding = 10
 // the byte-string encoding is big-endian, trailing zeroes don't count, so the encoding can be as short as
 // one byte.
 // Idea and some code by Axel Wagner
-func (nb numbits) toQNumber() []byte {
+func (nb numbits) toQNumber() qNumber {
 	// Iterate through the numbits 7 bits at a time, right to left, first bypassing bits that generate
 	// trailing zeroes in the encoded form. Note that index could go to 0 if the numbits value was uint(0)
 	// but that value represents NaN and can't appear in JSON
@@ -54,5 +54,5 @@ func (nb numbits) toQNumber() []byte {
 		b[index] = byte(nb & 0x7f)
 		nb >>= 7
 	}
-	return b[:]
+	return b
 }


### PR DESCRIPTION
Numeric comparisons now cover the entire range of float64 values.