### PR TITLE
improvement: alternative numbits conversion

### DIFF
--- a/numbits.go
+++ b/numbits.go
@@ -21,6 +21,7 @@ type numbits uint64
 // numbitsFromFloat64 converts a float64 value to its numbits representation.
 func numbitsFromFloat64(f float64) numbits {
 	u := math.Float64bits(f)
+	//nolint:gosec // disable G115
 	// transform without branching:
 	// if high bit is 0, xor with sign bit 1 << 63, else negate (xor with ^0)
 	mask := uint64(int64(u)>>63) | (1 << 63)

--- a/numbits.go
+++ b/numbits.go
@@ -23,7 +23,9 @@ func numbitsFromFloat64(f float64) numbits {
 	u := math.Float64bits(f)
 	//nolint:gosec // disable G115
 	// transform without branching:
-	// if high bit is 0, xor with sign bit 1 << 63, else negate (xor with ^0)
+	// if high bit is 0, xor with sign bit 1 << 63, else negate (xor with ^0).
+	// Using a sign extending right shift was proposed by Raph Levien in
+	// https://mastodon.online/@raph/113071041069390831
 	mask := uint64(int64(u)>>63) | (1 << 63)
 	return numbits(u ^ mask)
 }

--- a/numbits.go
+++ b/numbits.go
@@ -21,9 +21,9 @@ type numbits uint64
 // numbitsFromFloat64 converts a float64 value to its numbits representation.
 func numbitsFromFloat64(f float64) numbits {
 	u := math.Float64bits(f)
-	// transform without branching (inverse of numbits.Float64):
+	// transform without branching:
 	// if high bit is 0, xor with sign bit 1 << 63, else negate (xor with ^0)
-	mask := (u>>63)*^uint64(0) | (1 << 63)
+	mask := uint64(int64(u)>>63) | (1 << 63)
 	return numbits(u ^ mask)
 }
 


### PR DESCRIPTION
... and drop a doc-reference to a function that was not ported from the original implementation.

The improvement will use sign extension for a right shift for int64. This will fill all bits with the sign bit. There's no need for another constant.

This was sensibly suggested by Raph Levien in a mastodon thread: https://mastodon.online/@raph/113071041069390831