### PR TITLE
chore: bump go version to 1.22

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -12,7 +12,7 @@ jobs:
     name: Benchmarks
     strategy:
       matrix:
-        go-version: ["1.19"]
+        go-version: ["1.22"]
         platform: ["ubuntu-latest"]
 
     runs-on: ${{ matrix.platform }}

--- a/.github/workflows/dep-review.yaml
+++ b/.github/workflows/dep-review.yaml
@@ -11,7 +11,7 @@ jobs:
   dependency-review:
     strategy:
       matrix:
-        go-version: ["1.19"]
+        go-version: ["1.22"]
         platform: ["ubuntu-latest"]
     runs-on: ${{ matrix.platform }}
     timeout-minutes: 5

--- a/.github/workflows/go-lint.yaml
+++ b/.github/workflows/go-lint.yaml
@@ -12,7 +12,7 @@ jobs:
     name: Code Linting
     strategy:
       matrix:
-        go-version: ["1.19"]
+        go-version: ["1.22"]
         platform: ["ubuntu-latest"]
     runs-on: ${{ matrix.platform }}
     timeout-minutes: 5

--- a/.github/workflows/go-unit-tests.yaml
+++ b/.github/workflows/go-unit-tests.yaml
@@ -16,7 +16,7 @@ jobs:
     name: Unit Tests
     strategy:
       matrix:
-        go-version: ["1.19"]
+        go-version: ["1.22"]
         platform: ["ubuntu-latest"]
         type: ["Tests","Cover"] # run coverage as separate job w/out -race to avoid killing process
         include:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,7 +19,7 @@ jobs:
     timeout-minutes: 10
     strategy:
       matrix:
-        go-version: ["1.19"]
+        go-version: ["1.22"]
         platform: ["ubuntu-latest"]
     runs-on: ${{ matrix.platform }}
     env:

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -6,7 +6,6 @@ linters:
     - bodyclose
     - errname
     - errorlint
-    - exportloopref
     - gochecknoinits
     - goimports
     - goprintffuncname
@@ -29,3 +28,5 @@ issues:
   exclude-rules:
     - path: _test\.go
       text: "Use of weak random number generator" #gosec:G404
+    - path: _test\.go
+      text: "ST1018"

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module quamina.net/go/quamina
 
-go 1.19
+go 1.22

--- a/numbers_test.go
+++ b/numbers_test.go
@@ -14,7 +14,7 @@ import (
 func BenchmarkNumberMatching(b *testing.B) {
 	// we’re going to have a pattern that matches one of ten random floats, then we're going to throw
 	// 10K random events at it, 10% of which will match the pattern
-	rand.Seed(2325)
+	rand.New(rand.NewSource(2325))
 	pattern := `{"x": [`
 	var targets []string
 	for i := 0; i < 10; i++ {

--- a/numbits_test.go
+++ b/numbits_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestToQNumber(t *testing.T) {
-	rand.Seed(230948)
+	rand.New(rand.NewSource(230948))
 	var nbs []numbits
 	var utf8s [][]byte
 	for i := 0; i < 10000; i++ {
@@ -53,7 +53,7 @@ var (
 )
 
 func TestNumbits_Compare(t *testing.T) {
-	rand.Seed(203785)
+	rand.New(rand.NewSource(203785))
 	floats := append([]float64{}, specials...)
 
 	for i := 0; i < 1000; i++ {


### PR DESCRIPTION
This was necessitated by `go-unit-tests.yaml` containing

``
go install github.com/mfridman/tparse@latest
``

which uses the `toolchain` directive, not supported in go 1.19.  Note that AFAIK Quamina uses no post-1.19 features of Go.