### PR TITLE
Migrate to codecov v5

### DIFF
--- a/.github/workflows/go-unit-tests.yaml
+++ b/.github/workflows/go-unit-tests.yaml
@@ -67,9 +67,9 @@ jobs:
 
       - if: steps.codecov-enabled.outputs.files_exists == 'true'
         name: Upload Codecov Report
-        uses: codecov/codecov-action@e28ff129e5465c2c0dcc6f003fc735cb6ae0c673
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        uses: codecov/codecov-action@1e68e06f1dbfde0e4cefc87efeba9e4643565303
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Verify git clean
         shell: bash

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 .idea
 .DS_Store
 coverage.txt
+# codecov CLI and sig files
+codecov
+codecov.SHA256SUM*


### PR DESCRIPTION
Manually upgrade to codecov v5 due to changes in their CLI which creates verification files causing our git dirty check to fail.