### PR TITLE
Add patch version to go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module quamina.net/go/quamina
 
-go 1.22
+go 1.22.0


### PR DESCRIPTION
Comply with https://go.dev/doc/toolchain#version and address CodeQL warnings.

Closes: #396