### PR TITLE
pat: regexp infra plus dot

### DIFF
--- a/PATTERNS.md
+++ b/PATTERNS.md
@@ -59,7 +59,7 @@ Thus, the following Pattern would match both JSON events above:
 ### Numeric Values
 
 Quamina can match numeric values with precision and range exactly the same as that provided by 
-Go's `float64` data type, which is said to conform to IEE 754 `binary64`.
+Go's `float64` data type, which is said to conform to IEEE 754 `binary64`.
 
 ## Extended Patterns
 An **Extended Pattern** **MUST** be a JSON object containing
@@ -190,6 +190,12 @@ fact that they are escape characters for JSON as well as for Quamina.
 
 After a "\", the appearance of any character other than "*" or "\" is an error.
 
+### Regexp Pattern
+
+The Pattern Type of a Regexp Pattern is `regexp` and its value
+**MUST** be a string. For details of that string’s syntax see
+[Regular Expressions in Quamina](REGEXP.md).
+
 ### Shellstyle Pattern
 
 This is an earlier version of the Wildcard pattern, differing only that 
@@ -213,9 +219,4 @@ Quamina’s Patterns are inspired by those offered by
 the AWS EventBridge service, as documented in
 [Amazon EventBridge event patterns](https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-event-patterns.html).
 
-As of release 1.0, Quamina supports Exists and
-Anything-But Patterns, but does not yet support any other
-EventBridge patterns. Note that a
-Wildcard Pattern with a trailing `*` is equivalent
-to a `prefix` pattern.
-
+It is a goal of Quamina to eventually support all the patterns that EventBridge does.

--- a/README.md
+++ b/README.md
@@ -131,6 +131,13 @@ The following Patterns would match it:
   }
 }
 ```
+```json
+{
+  "Image": {
+    "Title": [ { "regexp": "View from .... Floor" } ]
+  }
+}
+```
 The syntax and semantics of Patterns are fully specified
 in [Patterns in Quamina](PATTERNS.md).
 

--- a/REGEXP.MD
+++ b/REGEXP.MD
@@ -1,0 +1,63 @@
+# Regular Expressions in Quamina
+
+**Regular Expressions** (hereinafter “regexps”) may appear in Quamina Regexp Patterns. 
+
+## Syntax
+
+The regexp syntax supported in Regexp Patterns are that specified in 
+[RFC 9485](https://datatracker.ietf.org/doc/rfc9485/), 
+*I-Regexp: An Interoperable Regular Expression Format*.
+
+There is one important syntactic difference. The backslash character “\” commonly
+used in regexp constructs for escaping metacharacters (as in `Stop\.`) and in such 
+constructs such as `\P{Lu}`, is “~” in Quamina regexps.
+
+“~” is used for this purpose because “\” is also used in Go string literals and
+in JSON. Thus, complexity is added to unit testing and fragments such as `\\\\` and even
+`\\\\\\\\` are regularly needed.  Conventional regexps may be turned into Quamina regexps
+by replacing occurrences of “\” with “~” wherever “\” is being used as a metacharacter. If a
+Quamina regexp needs to match the literal character “\”, it need not be escaped. For
+example, the common Go-language syntax for representing whitespace characters in code can
+be matched with the Quamina regexp `\[nrt]`, but the newline character, U+000A, would
+be matched by the Quamina regexp `~n`.
+
+When a regexp is used in a Quamina `addPattern()` call, an error is returned if the regexp
+contains a syntax error or if it uses a regexp feature that is not yet supported in the
+current release.
+
+## Features
+
+Regexps are being added to Quamina incrementally. The following list identifies the full
+set of planned features; it is not in any particular order. Those that are supported in the
+current release are bold-faced.
+
+`.` : **single-character matcher**
+
+`*` : zero-or-more matcher
+
+`+` : one-or-more matcher
+
+`?` : optional matcher
+
+`{lo,hi}` : occurrence-count matcher
+
+`()` : parenthetized sub-regexp
+
+`~p{}` : Unicode property matcher
+
+`~P{}` : Unicode property-complement matcher
+
+`[]` : character-class matcher
+
+`[^]` : complementary character-class matcher
+
+`|` logical alternatives
+
+## Semantics of “.”
+
+In Quamina regexps, the `.` metacharacter matches any Unicode character whose code point is
+among the *Unicode Scalars* as defined in Definition D76 in Section 3.9 of the Unicode Standard.
+This is the range of codepoints between U+0000 - U+D7FF inclusive, and U+E000 - U+10FFFF
+inclusive.
+
+Put another way, `.` matches all of the Unicode code points except those defined in the Unicode Standard as “Surrogates”.

--- a/cl2_test.go
+++ b/cl2_test.go
@@ -157,7 +157,16 @@ var (
 			"  }\n" +
 			"}",
 	}
+
 	equalsIgnoreCaseMatches = []int{131, 211, 1758, 825, 116386}
+	regexpRules             = []string{
+		"{\n" +
+			"  \"properties\": {\n" +
+			"    \"STREET\": [ { \"regexp\": \"B..CH\" } ]\n" +
+			"  }\n" +
+			"}",
+	}
+	regexpMatches = []int{220}
 	/* will add when we have numeric
 	complexArraysRules := []string{
 		"{\n" +
@@ -267,6 +276,10 @@ func TestRulerCl2(t *testing.T) {
 	bm = newBenchmarker()
 	bm.addRules(equalsIgnoreCaseRules, equalsIgnoreCaseMatches, true)
 	fmt.Printf("EQUALS_IGNORE-CASE events/sec: %.1f\n", bm.run(t, lines))
+
+	bm = newBenchmarker()
+	bm.addRules(regexpRules, regexpMatches, true)
+	fmt.Printf("REGEXP events/sec: %.1f\n", bm.run(t, lines))
 }
 
 type benchmarker struct {

--- a/code_gen/qtest-main.not-go
+++ b/code_gen/qtest-main.not-go
@@ -1,0 +1,405 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"os"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// TODO: Add a resWithSubtraction map[string]bool and keep running the tests and finding them and populating
+// the map and write valid:false if they're in the map.
+/*
+<test-case name="regex-syntax-0752">
+
+	<description>see regex-syntax-0001</description>
+	<created by="Michael Kay" on="2012-11-07"/>
+	<environment ref="regex-syntax"/>
+	<test>
+	   <param name="regex" as="xs:string" select="'[-e-g]+'"/>
+	   <param name="match" as="xs:string" select="''"/>
+	   <param name="nonmatch" as="xs:string" select="'ddd---eeefffggghhh,ddd---eeefffggghhh'"/>
+	   <param name="delimiter" as="xs:string" select="','"/>
+	   <initial-template name="go"/>
+	</test>
+	<result>
+	   <assert>/true</assert>
+	</result>
+
+</test-case>
+*/
+type regexSampleB struct {
+	regex     string
+	matches   []string
+	nomatches []string
+	valid     bool
+}
+
+var xHash *regexp.Regexp
+var isUnicodeBlock *regexp.Regexp
+var isMultiCharEscape *regexp.Regexp
+var isLeadingMCE *regexp.Regexp
+var lParenQM *regexp.Regexp
+var quantQM *regexp.Regexp
+var escDigit *regexp.Regexp
+var twoQMs *regexp.Regexp
+
+var resWithSubtraction = map[string]bool{
+	`[a-d-[b-c]]`:                    true,
+	`[^a-d-b-c]`:                     true,
+	`[a-b-[0-9]]+`:                   true,
+	`[a-c-[^a-c]]`:                   true,
+	`[a-z-[^a]]`:                     true,
+	`[a-c-1-4x-z-7-9]*`:              true,
+	`[a-a-x-x]+`:                     true,
+	`[abcd-[d]]+`:                    true,
+	`[\p{Ll}-[ae-z]]+`:               true,
+	`[\p{Nd}-[2468]]+`:               true,
+	`[\P{Lu}-[ae-z]]+`:               true,
+	`[abcd-[def]]+`:                  true,
+	`[\p{Ll}-[ae-z0-9]]+`:            true,
+	`[\p{Nd}-[2468az]]+`:             true,
+	`[\P{Lu}-[ae-zA-Z]]+`:            true,
+	`[abc-[defg]]+`:                  true,
+	`[\p{Ll}-[A-Z]]+`:                true,
+	`[\p{Nd}-[a-z]]+`:                true,
+	`[\P{Lu}-[\p{Lu}]]+`:             true,
+	`[\P{Lu}-[A-Z]]+`:                true,
+	`[\P{Nd}-[\p{Nd}]]+`:             true,
+	`[\P{Nd}-[2-8]]+`:                true,
+	`([0-9-[02468]]|[0-9-[13579]])+`: true,
+	`[abcdef-[^bce]]+`:               true,
+	`[^cde-[ag]]+`:                   true,
+	`[a-zA-Z-[aeiouAEIOU]]+`:         true,
+	`[abcd\-d-[bc]]+`:                true,
+	`[a-[a-f]]`:                      true,
+	`[a-[c-e]]+`:                     true,
+	`[a-d\--[bc]]+`:                  true,
+	`[abc\--[b]]+`:                   true,
+	`[abc\-z-[b]]+`:                  true,
+}
+
+var resReplacementHacks = map[string]string{
+	`[a-~~]`:   "[a-\\\\]",
+	`[~~-~{^]`: "[\\\\-~{^]",
+}
+
+var xmlBuiltin = map[string]rune{
+	"&amp":   '&',
+	"&apos;": '\'',
+	"&lt;":   '<',
+	"&gt;":   '>',
+	"&quot;": '"',
+}
+
+func main() {
+
+	testCase, err := regexp.Compile("<test-case")
+	if err != nil {
+		panic(err.Error())
+	}
+	regex, err := regexp.Compile(`<param name="regex" as="xs:string" select="'([^']*)'"/>`)
+	if err != nil {
+		panic(err.Error())
+	}
+	match, err := regexp.Compile(`<param name="match" as="xs:string" select="'([^']*)'"/>`)
+	if err != nil {
+		panic(err.Error())
+	}
+	nomatch, err := regexp.Compile(`<param name="nonmatch" as="xs:string" select="'([^']*)'"/>`)
+	if err != nil {
+		panic(err.Error())
+	}
+	delimiter, err := regexp.Compile(`<param name="delimiter" as="xs:string" select="'([^']*)'"/>`)
+	if err != nil {
+		panic(err.Error())
+	}
+	valid, err := regexp.Compile(`<assert>/true</assert>`)
+	if err != nil {
+		panic(err.Error())
+	}
+	invalid, err := regexp.Compile(`<error`)
+	if err != nil {
+		panic(err.Error())
+	}
+	fmt.Println(`package quamina
+	
+import (
+	"testing"
+)
+
+// This file produced by processing a set of XSD regexp syntax samples by Michael Kay
+// from the repo https://github.com/qt4cg/xslt40-test - thanks to Michael!
+// The code may be found in codegen/qtest-main.not-go. It is fairly horrible and my assumption 
+// is that it will never be run again; there is plenty of room for more regexp-related testing
+// but I think as much benefit has been extracted from this sample set as is reasonable to expect.
+
+type regexpSample struct {
+	regex     string
+	matches   []string
+	nomatches []string
+	valid     bool
+}
+
+func TestRegexpSamplesExist(t *testing.T) {
+	if len(regexpSamples) == 0 {
+		t.Error("no samples")
+	}
+}
+// test-case numbers are off by one, i.e. the first one below is actually for regex-syntax-0001
+var regexpSamples = []regexpSample{`)
+
+	/*
+		var regexpSamples = []regexpSample{
+			{
+				"foo",
+				[]string{"foo", "bar"},
+				[]string{"foo", "bar"},
+				true,
+			},
+		}
+	*/
+
+	xHash, err = regexp.Compile(`^&?#x([0-9a-fA-F]*);`)
+	if err != nil {
+		panic(err.Error())
+	}
+	isUnicodeBlock, err = regexp.Compile(`\\[pP]{[^LMNPZSC]`)
+	if err != nil {
+		panic(err.Error())
+	}
+	isMultiCharEscape, err = regexp.Compile(`[^\\]\\[sSiIcCdDwW]`)
+	if err != nil {
+		panic(err.Error())
+	}
+	isLeadingMCE, err = regexp.Compile(`^\\[sSiIcCdDwW]`)
+	if err != nil {
+		panic(err.Error())
+	}
+	lParenQM, err = regexp.Compile(`\(\?`)
+	if err != nil {
+		panic(err.Error())
+	}
+	quantQM, err = regexp.Compile(`{[0-9]*,[0-9]*}\?`)
+	if err != nil {
+		panic(err.Error())
+	}
+	escDigit, err = regexp.Compile(`\\10?$`)
+	if err != nil {
+		panic(err.Error())
+	}
+	twoQMs, err = regexp.Compile(`\?\?.`)
+	if err != nil {
+		panic(err.Error())
+	}
+	reader := bufio.NewReader(os.Stdin)
+	starting := true
+	rec := &regexSampleB{}
+	var rawMatches, rawNoMatches []byte
+	var rawDelimiter string
+	for {
+		bytes, _, err := reader.ReadLine()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			panic(err.Error())
+		}
+		if testCase.Match(bytes) {
+			if starting {
+				starting = false
+			} else {
+				//rawMatches = xHash.ReplaceAll(rawMatches, []byte(`0x${1}`))
+				//rawNoMatches = xHash.ReplaceAll([]byte(rawNoMatches), []byte(`0x${1}`))
+				rec.matches = strings.Split(string(rawMatches), rawDelimiter)
+				rec.nomatches = strings.Split(string(rawNoMatches), rawDelimiter)
+				report(rec, bytes)
+				rec = &regexSampleB{}
+			}
+			continue
+		}
+		var b [][]byte
+		b = regex.FindSubmatch(bytes)
+		if len(b) > 1 {
+			rec.regex = string(b[1])
+			continue
+		}
+		b = match.FindSubmatch(bytes)
+		if len(b) > 1 {
+			rawMatches = b[1]
+			continue
+		}
+		b = nomatch.FindSubmatch(bytes)
+		if len(b) > 1 {
+			rawNoMatches = b[1]
+			continue
+		}
+		b = delimiter.FindSubmatch(bytes)
+		if len(b) > 1 {
+			rawDelimiter = string(b[1])
+			continue
+		}
+		if valid.Match(bytes) {
+			rec.valid = true
+			continue
+		}
+		if invalid.Match(bytes) {
+			rec.valid = false
+			continue
+		}
+	}
+	//fmt.Println("\t\t\t},")
+	fmt.Println("\t\t}")
+}
+
+func prIndent(tabs int) string {
+	return "\t\t\t\t\t\t\t\t"[0:tabs]
+}
+func report(rec *regexSampleB, testcase []byte) {
+	/*
+		var regexpSamples = []regexpSample{
+			{
+				"foo",
+				[]string{"foo", "bar"},
+				[]string{"foo", "bar"},
+				true,
+			},
+		}
+
+	*/
+	// suppress things we don't handle
+	if isUnicodeBlock.MatchString(rec.regex) {
+		rec.valid = false
+	}
+	if isMultiCharEscape.MatchString(rec.regex) {
+		rec.valid = false
+	}
+	if isLeadingMCE.MatchString(rec.regex) {
+		rec.valid = false
+	}
+	if lParenQM.MatchString(rec.regex) {
+		rec.valid = false
+	}
+	if quantQM.MatchString(rec.regex) {
+		rec.valid = false
+	}
+	if escDigit.MatchString(rec.regex) {
+		rec.valid = false
+	}
+	if twoQMs.MatchString(rec.regex) {
+		rec.valid = false
+	}
+	if rec.regex == "(foo)(\\176)" {
+		rec.valid = false
+	}
+	badQuants := []string{
+		"+?", "*?",
+	}
+	for _, bq := range badQuants {
+		if strings.Contains(rec.regex, bq) {
+			rec.valid = false
+		}
+	}
+	_, ok := resWithSubtraction[rec.regex]
+	if ok {
+		rec.valid = false
+	}
+
+	cleaned := doString(rec.regex)
+	replacement, ok := resReplacementHacks[cleaned[1:len(cleaned)-1]]
+	if ok {
+		cleaned = `"` + replacement + `"`
+	}
+	fmt.Print(prIndent(3) + "// " + string(testcase) + "\n")
+	fmt.Print(prIndent(3) + "{\n")
+	fmt.Printf(prIndent(4)+"regex:%s,\n", cleaned)
+
+	if rec.valid {
+		fmt.Print(prIndent(4) + "matches:[]string{")
+		for i, m := range rec.matches {
+			cleaned = doString(m)
+			fmt.Print(cleaned)
+			if i < len(rec.matches)-1 {
+				fmt.Print(", ")
+			}
+		}
+		fmt.Println("},")
+
+		fmt.Print("\t\t\t\tnomatches:[]string{")
+		for i, m := range rec.nomatches {
+			cleaned = doString(m)
+			fmt.Print(cleaned)
+			if strings.Contains(string(testcase), "syntax-0471") {
+				_, _ = fmt.Fprintf(os.Stderr, "BOO in %s, out %s\n", m, cleaned)
+			}
+
+			if i < len(rec.nomatches)-1 {
+				fmt.Print(", ")
+			}
+		}
+		fmt.Println("},")
+		fmt.Println("\t\t\t\tvalid:true,")
+	} else {
+		fmt.Println("\t\t\t\tvalid:false,")
+	}
+	fmt.Println("\t\t\t},")
+}
+
+func doString(s string) string {
+	done := []byte{'"'}
+	i := 0
+	for i < len(s) {
+		var r rune
+		isEntity := false
+		for name, val := range xmlBuiltin {
+			if strings.HasPrefix(s[i:], name) {
+				r = val
+				i += len(name)
+				isEntity = true
+				break
+			}
+		}
+		if !isEntity {
+			matches := xHash.FindStringSubmatch(s[i:])
+			if len(matches) > 1 {
+				hex := matches[1]
+				value, err := strconv.ParseUint(hex, 16, 32)
+				if err != nil {
+					panic(err.Error())
+				}
+				r = rune(value)
+				i += len(matches[0])
+			} else {
+				r = rune(s[i])
+				i++
+			}
+		}
+		var t string
+		switch r {
+		case '\a':
+			t = `\a`
+		case '\b':
+			t = `\b`
+		case '\f':
+			t = `\f`
+		case '\n':
+			t = `\n`
+		case '\r':
+			t = `\r`
+		case '\v':
+			t = `\v`
+		case '\\':
+			t = `~`
+		case '"':
+			t = `\"`
+		default:
+			t = string([]rune{r})
+		}
+		done = append(done, []byte(t)...)
+	}
+	done = append(done, '"')
+	return string(done)
+}

--- a/core_matcher_test.go
+++ b/core_matcher_test.go
@@ -220,6 +220,7 @@ func TestExerciseMatching(t *testing.T) {
 		`{"Image": { "Thumbnail": { "Url": [ { "prefix": "https:" } ] } } }`,
 		`{"Image": { "Thumbnail": { "Url": [ "a", { "prefix": "https:" } ] } } }`,
 		`{"Image": { "Title": [ { "equals-ignore-case": "VIEW FROM 15th FLOOR" } ] } }`,
+		`{"Image": { "Title": [ { "regexp": "View from .... Floor" } ]  } }`,
 	}
 
 	var err error

--- a/pattern.go
+++ b/pattern.go
@@ -22,14 +22,17 @@ const (
 	prefixType
 	monocaseType
 	wildcardType
+	regexpType
 )
 
 // typedVal represents the value of a field in a pattern, giving the value and the type of pattern.
-// list is used to handle anything-but matches with multiple values.
+// - list is used to handle anything-but matches with multiple values.
+// - parsedRegexp only used for vType == regexpType
 type typedVal struct {
-	vType valType
-	val   string
-	list  [][]byte
+	vType        valType
+	val          string
+	list         [][]byte
+	parsedRegexp regexpRoot
 }
 
 // patternField represents a field in a pattern.
@@ -205,6 +208,9 @@ func readSpecialPattern(pb *patternBuild, valsIn []typedVal) (pathVals []typedVa
 		pathVals, err = readPrefixSpecial(pb, pathVals)
 	case "equals-ignore-case":
 		pathVals, err = readMonocaseSpecial(pb, pathVals)
+	case "regexp":
+		containsExclusive = tt
+		pathVals, err = readRegexpSpecial(pb, pathVals)
 	default:
 		err = errors.New("unrecognized in special pattern: " + tt)
 	}

--- a/pattern_test.go
+++ b/pattern_test.go
@@ -104,20 +104,20 @@ func TestPatternFromJSON(t *testing.T) {
 	}
 	w1 := []*patternField{{path: "x", vals: []typedVal{{vType: numberType, val: "2"}}}}
 	w2 := []*patternField{{path: "x", vals: []typedVal{
-		{literalType, "null", nil},
-		{literalType, "true", nil},
-		{literalType, "false", nil},
-		{stringType, `"hopp"`, nil},
-		{numberType, "3.072e-11", nil},
+		{literalType, "null", nil, nil},
+		{literalType, "true", nil, nil},
+		{literalType, "false", nil, nil},
+		{stringType, `"hopp"`, nil, nil},
+		{numberType, "3.072e-11", nil, nil},
 	}}}
 	w3 := []*patternField{
 		{path: "x\na", vals: []typedVal{
-			{numberType, "27", nil},
-			{numberType, "28", nil},
+			{numberType, "27", nil, nil},
+			{numberType, "28", nil, nil},
 		}},
 		{path: "x\nb\nm", vals: []typedVal{
-			{stringType, `"a"`, nil},
-			{stringType, `"b"`, nil},
+			{stringType, `"a"`, nil, nil},
+			{stringType, `"b"`, nil, nil},
 		}},
 	}
 	w4 := []*patternField{

--- a/prettyprinter.go
+++ b/prettyprinter.go
@@ -157,12 +157,28 @@ func (pp *prettyPrinter) nextString(n *faNext) string {
 }
 
 func branchChar(b byte) string {
+	replaceStr := []string{
+		"nul", "soh", "stx", "etx", "eot", "enq", "ack", "bel", "bs", "ht", "nl", "vt", "np", "cr", "so", "si", "dle",
+		"dc1", "dc2", "dc3", "dc4", "nak", "syn", "etb", "can", "em", "sub", "esc", "fs", "gs", "rs", "us", "sp",
+		"!", "\"", "#", "$", "%", "&", "'", "(", ")", "*", "+", ",", "-", ".", "/",
+		"0", "1", "2", "3", "4", "5", "6", "7", "8", "9",
+		":", ";", "<", "=", ">", "?", "@",
+		"A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L", "M", "N", "O", "P", "Q", "R",
+		"S", "T", "U", "V", "W", "X", "Y", "Z",
+		"[", "\\", "]", "^", "_", "`",
+		"a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p", "q", "r",
+		"s", "t", "u", "v", "w", "x", "y", "z",
+		"{", "|", "}", "~", "del"}
 	switch b {
 	// TODO: Figure out how to test commented-out cases
 	case valueTerminator:
-		return "ℵ"
+		return fmt.Sprintf("%x/ℵ", valueTerminator)
 	default:
-		return fmt.Sprintf("%c", b)
+		if b < 128 {
+			return fmt.Sprintf("%x/%s", b, replaceStr[b])
+		} else {
+			return fmt.Sprintf("%x/", b)
+		}
 	}
 }
 

--- a/prettyprinter_test.go
+++ b/prettyprinter_test.go
@@ -8,11 +8,11 @@ func TestPP(t *testing.T) {
 	pp := newPrettyPrinter(1)
 	table, _ := makeShellStyleFA([]byte(`"x*9"`), pp)
 	pp.labelTable(table, "START HERE")
-	wanted := ` 758[START HERE] '"' → 910[on " at 0]
- 910[on " at 0] 'x' → 821[gS at 2]
- 821[gS at 2] ε → 821[gS at 2] / '9' → 551[gX on 9 at 3]
- 551[gX on 9 at 3] '"' → 937[on " at 4]
- 937[on " at 4] 'ℵ' → 820[last step at 5]
+	wanted := ` 758[START HERE] '22/"' → 910[on " at 0]
+ 910[on " at 0] '78/x' → 821[gS at 2]
+ 821[gS at 2] ε → 821[gS at 2] / '39/9' → 551[gX on 9 at 3]
+ 551[gX on 9 at 3] '22/"' → 937[on " at 4]
+ 937[on " at 4] 'f5/ℵ' → 820[last step at 5]
  820[last step at 5]  [1 transition(s)]
 `
 	s := pp.printNFA(table)

--- a/regexp_nfa.go
+++ b/regexp_nfa.go
@@ -1,0 +1,272 @@
+package quamina
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+	"unicode/utf8"
+)
+
+// these types exported to facilitate building Unicode tables in code_gen
+type RunePair struct {
+	Lo, Hi rune
+}
+type RuneRange []RunePair
+
+type runeRangeIterator struct {
+	pairs     RuneRange
+	whichPair int
+	inPair    rune
+}
+
+func newRuneRangeIterator(rr RuneRange) (*runeRangeIterator, error) {
+	if len(rr) == 0 {
+		return nil, errors.New("empty range")
+	}
+	return &runeRangeIterator{pairs: rr, whichPair: 0, inPair: rr[0].Lo}, nil
+}
+
+// In the regular expressions represented by the I-Regexp syntax, the | connector has the lowest
+// precedence, so at the top level, it's a slice of what the ABNF calls branches - generate an NFA
+// for each branch and then take their union.
+// Inside a branch, the structure is obviously recursive because of the ()-group, which itself can
+// carry a slice of branches etc.  Aside from that, the branch contains a sequence of atom/quantifier
+// pairs.  All the "atom" syntax options describe ranges of characters and are well-represented by
+// the RuneRange type. This includes [] and \[pP]{whatever}.
+// All the forms of quantifiers can be described by pairs of numbers. ? is [0,1]. + is [1,♾️]. * is [0,♾️].
+// {m,n} ranges also, obviously.
+
+type regexpQuantifiedAtom struct {
+	isDot    bool
+	runes    RuneRange
+	quantMin int
+	quantMax int
+	subtree  regexpRoot // if non-nil, ()-enclosed subtree here
+}
+type regexpBranch []*regexpQuantifiedAtom
+type regexpRoot []regexpBranch
+
+func makeRegexpNFA(root regexpRoot) (*smallTable, *fieldMatcher) {
+	nextField := newFieldMatcher()
+	fa := newSmallTable()
+	for _, branch := range root {
+		nextBranch := makeOneRegexpBranchFA(branch, nextField)
+		fa = mergeFAs(fa, nextBranch, sharedNullPrinter)
+	}
+	return fa, nextField
+}
+
+// makeOneRegexpBranchFA - exploring… we know what the last step looks like, so we proceed back to
+// front through the members of the branch, which are quantified atoms. Each can be a runeRange (which
+// can be a single character or a dot or a subtree, in each case followed by a quantifier.
+// We know the last step, which points at the nextField argument.
+func makeOneRegexpBranchFA(branch regexpBranch, nextField *fieldMatcher) *smallTable {
+	nextStep := makeNFATrailer(nextField)
+	var step *faNext
+	var table *smallTable
+	// TODO: Assuming this works, rewrite a bunch of other make*NFA calls in this style, without recursion
+	for index := len(branch) - 1; index >= 0; index-- {
+		qa := branch[index]
+		if qa.isDot {
+			table = makeDotFA(nextStep)
+			step = &faNext{states: []*faState{{table: table}}}
+		} else if qa.subtree != nil {
+			panic("Not supported " + rxfParenGroup)
+		} else {
+			// it's a rune range
+			if len(qa.runes) != 1 || qa.quantMin != 1 || qa.quantMax != 1 {
+				panic("Not supported: quantifiers")
+			}
+
+			// just match a rune
+			u, _ := runeToUTF8(qa.runes[0].Lo)
+			trailer := makeFAFragment(u, nextStep, sharedNullPrinter)
+			table = makeSmallTable(nil, []byte{u[0]}, []*faNext{trailer})
+			step = &faNext{states: []*faState{{table: table}}}
+		}
+		nextStep = step
+	}
+	return table
+}
+
+// makeNFATrailer generates the last two steps in every NFA, because all field values end with the
+// valueTerminator marker, so you need the field-matched state and you need another state that branches
+// to it based on valueTerminator
+// TODO: Prove that this is useful in other make*NFA scenarios
+func makeNFATrailer(nextField *fieldMatcher) *faNext {
+	matchState := &faState{
+		table:            newSmallTable(),
+		fieldTransitions: []*fieldMatcher{nextField},
+	}
+	matchStep := &faNext{[]*faState{matchState}}
+	table := makeSmallTable(nil, []byte{valueTerminator}, []*faNext{matchStep})
+	return &faNext{states: []*faState{{table: table}}}
+}
+
+func makeRuneRangeNFA(rr RuneRange, next *faState, pp *prettyPrinter) (*smallTable, error) {
+	// these have to be in increasing order to work
+	sort.Slice(rr, func(i, j int) bool { return rr[i].Lo < rr[j].Lo })
+
+	// turn the slice of hi/lo inclusive endpoints into a slice of utf8 encodings
+	var utf8Range [][]byte
+	ri, err := newRuneRangeIterator(rr)
+	if err != nil {
+		return nil, err
+	}
+	// for each rune
+	for r := ri.next(); r != -1; r = ri.next() {
+		buf, err := runeToUTF8(r)
+		if err != nil {
+			continue
+		}
+		utf8Range = append(utf8Range, buf)
+	}
+	pp.labelTable(next.table, "DESTINATION")
+	step := &faNext{[]*faState{next}}
+	table := newSmallTable()
+	pp.labelTable(table, "ROOT")
+	makeRuneRangeNFALevel(utf8Range, 0, table, step, pp)
+	return table, nil
+}
+
+type runeSubrange struct {
+	lo int
+	hi int
+}
+
+// makeRuneRangeNFALevel fills in the transitions in the 'table' argument based on the bytes in all the utf8Range
+// byte slices
+func makeRuneRangeNFALevel(utf8Range [][]byte, level int, targetTable *smallTable, next *faNext, pp *prettyPrinter) {
+	unpacked := unpackTable(targetTable)
+	nextLevelSubrange := make(map[byte]*runeSubrange)
+	nextLevelSteps := make(map[byte]*faNext)
+
+	var lastByte byte = 0xff
+	var subrange *runeSubrange
+	for index, u := range utf8Range {
+		if level >= len(u) {
+			continue
+		}
+		b := u[level]
+		if b != lastByte {
+			subrange = &runeSubrange{lo: index, hi: index}
+			nextLevelSubrange[b] = subrange
+			lastByte = b
+		} else {
+			subrange.hi = index
+		}
+
+		if len(u) > (level + 1) {
+			nextStep, ok := nextLevelSteps[b]
+			if !ok {
+				table := newSmallTable()
+				nextState := &faState{table: table}
+				asRune, _ := utf8.DecodeRune(u)
+				pp.labelTable(table, fmt.Sprintf("For level %d in %x", level+1, asRune))
+				nextStep = &faNext{[]*faState{nextState}}
+				nextLevelSteps[b] = nextStep
+			}
+			unpacked[b] = nextStep
+		} else {
+			unpacked[b] = next
+		}
+	}
+	for b, nextStep := range nextLevelSteps {
+		subrange = nextLevelSubrange[b]
+		makeRuneRangeNFALevel(utf8Range[subrange.lo:subrange.hi+1], level+1, nextStep.states[0].table, next, pp)
+	}
+
+	targetTable.pack(unpacked)
+}
+
+func makeDotFA(dest *faNext) *smallTable {
+	if dest == nil {
+		dest = &faNext{}
+	}
+	sLast := &smallTable{
+		ceilings: []byte{0x80, 0xc0, byte(byteCeiling)},
+		steps:    []*faNext{nil, dest, nil},
+	}
+	targetLast := &faNext{states: []*faState{{table: sLast}}}
+	sLastInter := &smallTable{
+		ceilings: []byte{0x80, 0xc0, byte(byteCeiling)},
+		steps:    []*faNext{nil, targetLast, nil},
+	}
+	targetLastInter := &faNext{states: []*faState{{table: sLastInter}}}
+	sFirstInter := &smallTable{
+		ceilings: []byte{0x80, 0xc0, byte(byteCeiling)},
+		steps:    []*faNext{nil, targetLastInter, nil},
+	}
+	targetFirstInter := &faNext{states: []*faState{{table: sFirstInter}}}
+
+	sE0 := &smallTable{
+		ceilings: []byte{0xa0, 0xc0, byte(byteCeiling)},
+		steps:    []*faNext{nil, targetLast, nil},
+	}
+	targetE0 := &faNext{states: []*faState{{table: sE0}}}
+
+	sED := &smallTable{
+		ceilings: []byte{0x80, 0xA0, byte(byteCeiling)},
+		steps:    []*faNext{nil, targetLast, nil},
+	}
+	targetED := &faNext{states: []*faState{{table: sED}}}
+
+	sF0 := &smallTable{
+		ceilings: []byte{0x90, 0xC0, byte(byteCeiling)},
+		steps:    []*faNext{nil, targetLastInter, nil},
+	}
+	targetF0 := &faNext{states: []*faState{{table: sF0}}}
+
+	sF4 := &smallTable{
+		ceilings: []byte{0x80, 0x90, byte(byteCeiling)},
+		steps:    []*faNext{nil, targetLastInter, nil},
+	}
+	targetF4 := &faNext{states: []*faState{{table: sF4}}}
+
+	// for reference, see https://www.tbray.org/ongoing/When/202x/2024/12/29/Matching-Dot-Redux
+	return &smallTable{
+		ceilings: []byte{
+			0x80,              // 0
+			0xC2,              // 1
+			0xE0,              // 2
+			0xE1,              // 3
+			0xED,              // 4
+			0xEE,              // 5
+			0xF0,              // 6
+			0xF1,              // 7
+			0xF4,              // 8
+			0xF5,              // 9
+			byte(byteCeiling), // 10
+		},
+		steps: []*faNext{
+			dest,             // 0
+			nil,              // 1
+			targetLast,       // 2
+			targetE0,         // 3
+			targetLastInter,  // 4
+			targetED,         // 5
+			targetLastInter,  // 6
+			targetF0,         // 7
+			targetFirstInter, // 8
+			targetF4,         // 9
+			nil,              // 10
+		},
+	}
+}
+
+func (i *runeRangeIterator) next() rune {
+	if i.inPair <= i.pairs[i.whichPair].Hi {
+		r := i.inPair
+		i.inPair++
+		return r
+	}
+	// will blow up on empty pair, could put a check in, or just don't generate them
+	// while parsing regexp
+	i.whichPair++
+	if i.whichPair == len(i.pairs) {
+		return -1
+	}
+	r := i.pairs[i.whichPair].Lo
+	i.inPair = r + 1
+	return r
+}

--- a/regexp_nfa_test.go
+++ b/regexp_nfa_test.go
@@ -1,0 +1,304 @@
+package quamina
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"unicode"
+)
+
+var unicodeAssignables = RuneRange{
+	{0x9, 0x9}, {0xA, 0xA}, {0xD, 0xD},
+	{0x20, 0x7E},
+	{0xA0, 0xD7FF},
+	{0xE000, 0xFDCF},
+	{0xFDF0, 0xFFFD},
+	{0x10000, 0x1FFFD}, {0x20000, 0x2FFFD},
+	{0x30000, 0x3FFFD}, {0x40000, 0x4FFFD},
+	{0x50000, 0x5FFFD}, {0x60000, 0x6FFFD},
+	{0x70000, 0x7FFFD}, {0x80000, 0x8FFFD},
+	{0x90000, 0x9FFFD}, {0xA0000, 0xAFFFD},
+	{0xB0000, 0xBFFFD}, {0xC0000, 0xCFFFD},
+	{0xD0000, 0xDFFFD}, {0xE0000, 0xEFFFD},
+	{0xF0000, 0xFFFFD}, {0x100000, 0x10FFFD},
+}
+
+var unicodeScalars = RuneRange{
+	{0x0, 0xD800}, {0xE000, 0x10FFFF},
+}
+
+func TestExploreUTF8Form(t *testing.T) {
+	bads := [][]byte{
+		{0xc0, 0x80},             //0
+		{0xc0, 0x8f},             //1
+		{0xc1, 0x80},             //2
+		{0xc1, 0x8f},             //3
+		{0xe0, 0x9f, 0x80},       //4
+		{0xe0, 0xc0, 0x80},       //5
+		{0xe0, 0x9f, 0x80},       //6
+		{0xed, 0xa0, 0x80},       //7
+		{0xed, 0xb0, 0x80},       //8
+		{0xed, 0xbf, 0x80},       //9
+		{0xf0, 0x80, 0x80, 0x80}, //10
+		{0xf0, 0x8f, 0x80, 0x80}, //11
+		{0xf4, 0xa0, 0x80, 0x80}, //12
+		{0xf4, 0xb0, 0x80, 0x80}, //13
+		{0xf4, 0xbf, 0x80, 0x80}, //14
+		{0x80},                   //15
+		{0xfe},                   //16,
+	}
+
+	wantFM := &fieldMatcher{}
+	targetState := &faState{table: newSmallTable(), fieldTransitions: []*fieldMatcher{wantFM}}
+	table := makeDotFA(&faNext{states: []*faState{targetState}})
+	var matchers []*fieldMatcher
+	var got []*fieldMatcher
+	for i, bad := range bads {
+		got = traverseDFA(table, bad, matchers)
+		if len(got) != 0 {
+			t.Errorf("accepted index %d", i)
+		}
+	}
+}
+
+func TestDotSemantics(t *testing.T) {
+	wantFM := &fieldMatcher{}
+	targetState := &faState{table: newSmallTable(), fieldTransitions: []*fieldMatcher{wantFM}}
+	table := makeDotFA(&faNext{states: []*faState{targetState}})
+	var matchers []*fieldMatcher
+	var got []*fieldMatcher
+	var r rune
+	for r = 0; r < unicode.MaxRune; r++ {
+		// These actually would work because the string cast below would convert the char to �
+		if r >= 0xD800 && r <= 0xDFFF {
+			continue
+		}
+		got = traverseDFA(table, []byte(string([]rune{r})), matchers)
+		if len(got) != 1 || got[0] != wantFM {
+			t.Errorf("failed on %x", r)
+		}
+		matchers = matchers[:0]
+	}
+
+	// goodUTF are the UTF-8 sequences for 0, U+D7FF, U+E000, and U+10F0000, which should all pass.
+	goodUTF8 := [][]byte{
+		{0}, {0xED, 0x9F, 0xBF}, {0xE8, 0x80, 0x80}, {0xF4, 0x8F, 0x80, 0x80},
+	}
+	// badUTF are the UTF-8 sequences for surrogates U+D800, U+DAAA, and U+DFFF, which should not pass.
+	// They are provided as literals because Go refuses to provide the UTF-8 for surrogates
+	badUTF8 := [][]byte{
+		{0xED, 0xA0, 0x80}, {0xED, 0xAA, 0xAA}, {0xED, 0xBF, 0xBF},
+	}
+
+	for _, good := range goodUTF8 {
+		got = traverseDFA(table, good, matchers)
+		if len(got) != 1 || got[0] != wantFM {
+			t.Errorf("failed on non-surrogate %04x", r)
+		}
+		matchers = matchers[:0]
+	}
+	for _, bad := range badUTF8 {
+		got = traverseDFA(table, bad, matchers)
+		if len(got) != 0 {
+			t.Errorf("accepted surrogate %04x", r)
+		}
+		matchers = matchers[:0]
+	}
+}
+
+func containsFM(t *testing.T, fms []*fieldMatcher, wanted *fieldMatcher) bool {
+	t.Helper()
+	for _, fm := range fms {
+		if fm == wanted {
+			return true
+		}
+	}
+	return false
+}
+
+func TestMakeDotRegexpNFA(t *testing.T) {
+	runes := []rune{0x26, 0x416, 0x4e2d, 0x10346} // 1, 2, 3, & 4 bytes in UTF-8
+	resAndMatches := map[string]string{
+		"a.b": "aXb",
+		".ab": "Xab",
+		"ab.": "abX",
+	}
+	for re, match := range resAndMatches {
+		parsed, err := readRegexp(re)
+		if err != nil {
+			t.Error("Parse " + err.Error())
+		}
+		st, wanted := makeRegexpNFA(parsed.tree)
+		bufs := &bufpair{}
+		for _, r := range runes {
+			// func traverseNFA(table *smallTable, val []byte, transitions []*fieldMatcher, bufs *bufpair) []*fieldMatcher {
+			toMatch := strings.Replace(match, "X", string([]rune{r}), 1)
+			found := traverseNFA(st, []byte(toMatch), nil, bufs)
+			if len(found) == 0 {
+				t.Errorf("struck out matching %s to /%s/", match, re)
+			}
+			if !containsFM(t, found, wanted) {
+				t.Errorf("Wrong FM returned matching %s to /%s/", match, re)
+			}
+		}
+	}
+	resAndNonMatches := map[string][]string{
+		"a.b": {"ab", "axyb"},
+		".ab": {"ab", "zzab"},
+		"ab.": {"ab", "abab"},
+	}
+	for re, nonMatches := range resAndNonMatches {
+		parsed, err := readRegexp(re)
+		if err != nil {
+			t.Error("Parse " + err.Error())
+		}
+		st, _ := makeRegexpNFA(parsed.tree)
+		bufs := &bufpair{}
+		for _, nonMatch := range nonMatches {
+			found := traverseNFA(st, []byte(nonMatch), nil, bufs)
+			if len(found) != 0 {
+				t.Errorf("false match to %s to /%s/", nonMatch, re)
+			}
+		}
+	}
+
+	daodechingorig := "道可道，非常道。名可名"
+	daodechingpatterns := []string{
+		"道可道.非常道.名可名",
+		"道..，非..。名.名",
+		".可道，非常道。名..",
+		"....非常道。名可名",
+		"道可道，非常...可名",
+	}
+	bufs := &bufpair{}
+	for _, pat := range daodechingpatterns {
+		parsed, err := readRegexp(pat)
+		if err != nil {
+			t.Error("Parse failure: " + pat)
+		}
+		st, wanted := makeRegexpNFA(parsed.tree)
+		found := traverseNFA(st, []byte(daodechingorig), nil, bufs)
+		if len(found) != 1 {
+			t.Errorf("Failed to match ")
+		}
+		if !containsFM(t, found, wanted) {
+			t.Errorf("missed FM in matching %s to /%s", daodechingorig, pat)
+		}
+	}
+}
+
+func TestMultiLengthRR(t *testing.T) {
+	ranges := []RuneRange{unicodeScalars, unicodeAssignables}
+	rangeNames := []string{"Scalars", "assignables"}
+
+	// get UTF-8 versions of all the code points
+	for index, rr := range ranges {
+		fmt.Println(" " + rangeNames[index])
+		var multiLengthTest = rr
+
+		pp := newPrettyPrinter(2335)
+		wantFM := &fieldMatcher{}
+		next := &faState{table: newSmallTable(), fieldTransitions: []*fieldMatcher{wantFM}}
+		st, err := makeRuneRangeNFA(rr, next, pp)
+		if err != nil {
+			t.Error(err.Error())
+		}
+
+		matchers := []*fieldMatcher{}
+		var got []*fieldMatcher
+		for _, rp := range multiLengthTest {
+			got = traverseDFA(st, []byte(string([]rune{rp.Lo})), matchers)
+			if len(got) != 1 || got[0] != wantFM {
+				t.Errorf("failed on %x", rp.Lo)
+			}
+		}
+		nfaSize(t, st)
+	}
+}
+
+func nfaSize(t *testing.T, st *smallTable) {
+	t.Helper()
+	s := &statsAccum{}
+	nfaSizeStep(t, st, s, 0)
+	fmt.Printf("Tables: %d\n", s.stCount)
+	fmt.Printf("Avg size: %d\n", int(float64(s.stEntries)/float64(s.stCount)))
+	fmt.Printf("Max size: %d\n", s.stMax)
+	fmt.Printf("Max depth %d\n", s.stDepth)
+}
+func nfaSizeStep(t *testing.T, st *smallTable, s *statsAccum, depth int) {
+	t.Helper()
+	if depth > s.stDepth {
+		s.stDepth = depth
+	}
+	s.stCount++
+	tSize := len(st.ceilings)
+	if tSize > 1 {
+		if tSize > s.stMax {
+			s.stMax = tSize
+		}
+		s.stTblCount++
+		s.stEntries += len(st.ceilings)
+		s.stEpsilon += len(st.epsilon)
+		if len(st.epsilon) > s.stEpMax {
+			s.stEpMax = len(st.epsilon)
+		}
+	}
+	for _, next := range st.steps {
+		if next != nil {
+			for _, step := range next.states {
+				nfaSizeStep(t, step.table, s, depth+1)
+			}
+		}
+	}
+}
+
+/* useful for debugging
+func showUTF8(t *testing.T, lo rune, hi rune) {
+	t.Helper()
+	for r := lo; r < hi; r++ {
+		rl := utf8.RuneLen(r)
+		if rl == -1 {
+			fmt.Printf("invalid rune value %x", r)
+			continue
+		}
+		buf := make([]byte, rl)
+		_ = utf8.EncodeRune(buf, r)
+		fmt.Printf("%x/%c: %d:", r, r, len(buf))
+		for _, b := range buf {
+			fmt.Printf(" %x,", b)
+		}
+		fmt.Println()
+	}
+}
+*/
+
+func TestRRiterator(t *testing.T) {
+	rr := RuneRange{
+		{'a', 'c'},
+		{'f', 'f'},
+		{'g', 'i'},
+	}
+
+	wanteds := []rune{'a', 'b', 'c', 'f', 'g', 'h', 'i'}
+	i, err := newRuneRangeIterator(rr)
+	if err != nil {
+		t.Error(err.Error())
+	}
+	for index, wanted := range wanteds {
+		r := i.next()
+		if r != wanted {
+			t.Errorf("mismatch at %d, %c != %c", index, r, wanted)
+		}
+	}
+}
+
+func TestBasicRRNFABuilding(t *testing.T) {
+	rr := RuneRange{{'a', 'c'}}
+	pp := newPrettyPrinter(2335)
+	next := &faState{table: newSmallTable()}
+	st, err := makeRuneRangeNFA(rr, next, pp)
+	if err != nil {
+		t.Error(err.Error())
+	}
+	fmt.Println("ST: " + pp.printNFA(st))
+}

--- a/regexp_parse.go
+++ b/regexp_parse.go
@@ -1,0 +1,85 @@
+package quamina
+
+import (
+	"fmt"
+	"unicode/utf8"
+)
+
+// regexpParse represents the state of a regexp read, validate, and parse project
+type regexpParse struct {
+	bytes     []byte
+	index     int
+	lastIndex int
+	nesting   []bool
+	features  *regexpFeatureChecker
+	tree      regexpRoot
+}
+
+func (r *regexpParse) nest() {
+	r.nesting = append(r.nesting, true)
+}
+
+// unNest is only called after isNested
+func (r *regexpParse) unNest() {
+	r.nesting = r.nesting[0 : len(r.nesting)-1]
+}
+
+func (r *regexpParse) isNested() bool {
+	return len(r.nesting) > 0
+}
+
+func newRxParseState(t []byte) *regexpParse {
+	return &regexpParse{bytes: t, features: defaultRegexpFeatureChecker()}
+}
+
+func (r *regexpParse) nextRune() (rune, error) {
+	if r.index >= len(r.bytes) {
+		return 0, errRegexpEOF
+	}
+	r.lastIndex = r.index
+	c, length := utf8.DecodeRune(r.bytes[r.index:])
+	if c == utf8.RuneError {
+		return 0, fmt.Errorf("UTF-8 encoding error at offset %d", r.lastOffset())
+	}
+	r.index += length
+	return c, nil
+}
+
+// require checks to see if the first rune matches the supplied argument. If it fails, it doesn't back up or
+// recover or anything, on the assumption that you're giving up.
+func (r *regexpParse) require(wanted rune) error {
+	got, err := r.nextRune()
+	if err != nil {
+		return err
+	}
+	if got != wanted {
+		return fmt.Errorf("incorrect character at %d; got %c wanted %c", r.lastOffset(), got, wanted)
+	}
+	return nil
+}
+
+func (r *regexpParse) bypassOptional(c rune) (bool, error) {
+	next, err := r.nextRune()
+	if err != nil {
+		return false, err
+	}
+	if next != c {
+		r.backup1(next)
+	}
+	return next == c, nil
+}
+
+func (r *regexpParse) backup1(oneRune rune) {
+	r.index -= utf8.RuneLen(oneRune)
+}
+
+func (r *regexpParse) offset() int {
+	return r.index
+}
+func (r *regexpParse) lastOffset() int {
+	return r.lastIndex
+}
+
+func (r *regexpParse) isEmpty() bool {
+	return r.index >= len(r.bytes)
+}

--- a/regexp_parse_test.go
+++ b/regexp_parse_test.go
@@ -1,0 +1,117 @@
+package quamina
+
+import (
+	"errors"
+	"testing"
+	"unicode/utf8"
+)
+
+func TestBasicRunelist(t *testing.T) {
+	bytes := []byte("foo")
+	r := newRxParseState(bytes)
+	for i, b := range bytes {
+		next, err := r.nextRune()
+		if err != nil {
+			t.Errorf("err at %d", i)
+		}
+		if next != rune(b) {
+			t.Errorf("mismatch at %d", i)
+		}
+	}
+	_, err := r.nextRune()
+	if !errors.Is(err, errRegexpEOF) {
+		t.Error("missed EOF")
+	}
+	if !r.isEmpty() {
+		t.Error("missed empty")
+	}
+}
+
+func TestBadUTF8(t *testing.T) {
+	bad := []byte{0xF8}
+	ps := newRxParseState(bad)
+	_, err := ps.nextRune()
+	if err == nil {
+		t.Error("bad UTF8")
+	}
+}
+
+func TestVariablePlaneRunelist(t *testing.T) {
+	runes := []rune{'&', 0x416, 0x4E2D, 0x10346}
+	lengths := []int{1, 2, 3, 4}
+	list := newRxParseState([]byte(string(runes)))
+	read := 0
+	for i := range runes {
+		r, err := list.nextRune()
+		read += utf8.RuneLen(r)
+		if err != nil {
+			t.Errorf("err at %d", i)
+		}
+		if r != runes[i] {
+			t.Errorf("mismatch at %d", i)
+		}
+		if utf8.RuneLen(r) != lengths[i] {
+			t.Errorf("length mismatch at %d", i)
+		}
+		if read != list.offset() {
+			t.Errorf("wrong length at %d", i)
+		}
+	}
+	if !list.isEmpty() {
+		t.Error("Missed empty")
+	}
+	for i := 3; i >= 0; i-- {
+		list.backup1(runes[i])
+		read -= utf8.RuneLen(runes[i])
+		if list.offset() != read {
+			t.Errorf("wrong offset at %d", i)
+		}
+	}
+	if list.offset() != 0 {
+		t.Error("offset not 0")
+	}
+}
+
+func TestRuneListRequire(t *testing.T) {
+	r := newRxParseState([]byte("foo"))
+	err := r.require('f')
+	if err != nil {
+		t.Error("require mode 1")
+	}
+	r = newRxParseState([]byte("foo"))
+	err = r.require('É')
+	if err == nil {
+		t.Error("require mode 2")
+	}
+	r = newRxParseState([]byte("Éé"))
+	err = r.require('É')
+	if err != nil {
+		t.Error("require mode 3")
+	}
+	r = newRxParseState([]byte("Éé"))
+	err = r.require('é')
+	if err == nil {
+		t.Error("require mode 4")
+	}
+}
+
+func TestRuneListBypass(t *testing.T) {
+	r := newRxParseState([]byte("Éé"))
+	_, err := r.bypassOptional('é')
+	if err != nil {
+		t.Error("bypass mode 1")
+	}
+	next, err := r.nextRune()
+	if err != nil || next != 'É' {
+		t.Error("bypass mode 2")
+	}
+	r = newRxParseState([]byte("Éé"))
+	_, err = r.bypassOptional('x')
+	if err != nil {
+		t.Error("bypass mode 3")
+	}
+	next, err = r.nextRune()
+	if err != nil || next != 'É' {
+		t.Error("bypass mode 4")
+	}
+}

--- a/regexp_reader.go
+++ b/regexp_reader.go
@@ -1,0 +1,663 @@
+package quamina
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"strconv"
+	"unicode/utf8"
+)
+
+// Reads a subset of regular expressions as defined in I-Regexp, RFC 9485
+// At the current time, represents a subset of a subset. I-Regexp support will be
+// built incrementally, adding features until full compatibility is achieved. The code
+// will not allow the use of patterns containing regexps that rely on features that are
+// not yet implemented.
+
+// Note that since the regexp is composed of runes, i.e. Unicode code points, and since we use Go's built-in
+// utf8.Decode()/Encode() to roundtrip between UTF-8 []bytes and code points, surrogate code points can neither
+// be used in a regular expression nor will they be matched if they show up in an Event.
+
+type regexpFeature string
+
+const (
+	rxfDot          regexpFeature = "'.' single-character matcher"
+	rxfStar         regexpFeature = "'*' zero-or-more matcher"
+	rxfPlus         regexpFeature = "'+' one-or-more matcher"
+	rxfQM           regexpFeature = "'?' optional matcher"
+	rxfRange        regexpFeature = "'{}' range matcher"
+	rxfParenGroup   regexpFeature = "() parenthetized group"
+	rxfProperty     regexpFeature = "~[Pp]-prefixed {}-enclosed Unicode property matcher"
+	rxfClass        regexpFeature = "[]-enclosed character-class matcher"
+	rxfNegatedClass regexpFeature = "[^]-enclosed negative character-class matcher"
+	rxfOrBar        regexpFeature = "|-separated logical alternatives"
+)
+
+const regexpQuantifierMax = 100 // TODO: make this into an option
+
+const Escape rune = '~'
+
+func runeToUTF8(r rune) ([]byte, error) {
+	rl := utf8.RuneLen(r)
+	if rl == -1 {
+		return nil, errors.New("ill-formed UTF-8")
+	}
+	buf := make([]byte, rl)
+	_ = utf8.EncodeRune(buf, r)
+	return buf, nil
+}
+
+func readRegexpSpecial(pb *patternBuild, valsIn []typedVal) (pathVals []typedVal, err error) {
+	pathVals = valsIn
+	t, err := pb.jd.Token()
+	if err != nil {
+		return
+	}
+
+	regexpString, ok := t.(string)
+	if !ok {
+		err = errors.New("value for 'regexp' must be a string")
+		return
+	}
+	val := typedVal{
+		vType: regexpType,
+		val:   `"` + regexpString + `"`,
+	}
+	var parse *regexpParse
+	parse, err = readRegexp(val.val)
+	if err != nil {
+		return
+	}
+	unimplemented := parse.features.foundUnimplemented()
+	if len(unimplemented) != 0 {
+		problem := "found unimplemented features:"
+		for _, ui := range unimplemented {
+			problem += " " + string(ui)
+		}
+		return nil, errors.New(problem)
+	}
+
+	val.parsedRegexp = parse.tree
+	pathVals = append(pathVals, val)
+	// has to be } or tokenizer will throw error
+	_, err = pb.jd.Token()
+
+	return
+}
+
+type regexpFeatureChecker struct {
+	implemented map[regexpFeature]bool
+	found       map[regexpFeature]bool
+}
+
+var implementedRegexpFeatures = map[regexpFeature]bool{
+	rxfDot: true,
+}
+
+func defaultRegexpFeatureChecker() *regexpFeatureChecker {
+	return &regexpFeatureChecker{implemented: implementedRegexpFeatures, found: make(map[regexpFeature]bool)}
+}
+
+func (fc *regexpFeatureChecker) recordFeature(feature regexpFeature) {
+	fc.found[feature] = true
+}
+
+func (fc *regexpFeatureChecker) foundUnimplemented() []regexpFeature {
+	var unimplemented []regexpFeature
+	for feature := range fc.found {
+		_, ok := fc.implemented[feature]
+		if !ok {
+			unimplemented = append(unimplemented, feature)
+		}
+	}
+	return unimplemented
+}
+
+var errRegexpEOF = errors.New("end of string")
+var errRegexpStuck = errors.New("unable to move forward")
+
+// regexps are anchored by definition, i.e. behave as if they began with ^ and ended with $
+// here is the grammar from the RFC 9485, I-Regexp, in IETF ABNF syntax
+/*
+i-regexp = branch *( "|" branch )
+branch = *piece
+piece = atom [ quantifier ]
+quantifier = ( "*" / "+" / "?" ) / range-quantifier
+range-quantifier = "{" QuantExact [ "," [ QuantExact ] ] "}"
+QuantExact = 1*%x30-39 ; '0'-'9'
+
+atom = NormalChar / charClass / ( "(" i-regexp ")" )
+NormalChar = ( %x00-27 / "," / "-" / %x2F-3E ; '/'-'>'
+ / %x40-5A ; '@'-'Z'
+ / %x5E-7A ; '^'-'z'
+ / %x7E-D7FF ; skip surrogate code points
+ / %xE000-10FFFF )
+charClass = "." / SingleCharEsc / charClassEsc / charClassExpr
+SingleCharEsc = "\" ( %x28-2B ; '('-'+'
+ / "-" / "." / "?" / %x5B-5E ; '['-'^'
+ / %s"n" / %s"r" / %s"t" / %x7B-7D ; '{'-'}'
+ )
+charClassEsc = catEsc / complEsc
+charClassExpr = "[" [ "^" ] ( "-" / CCE1 ) *CCE1 [ "-" ] "]"
+CCE1 = ( CCchar [ "-" CCchar ] ) / charClassEsc
+CCchar = ( %x00-2C / %x2E-5A ; '.'-'Z'
+ / %x5E-D7FF ; skip surrogate code points
+ / %xE000-10FFFF ) / SingleCharEsc
+catEsc = %s"\p{" charProp "}"
+complEsc = %s"\P{" charProp "}"
+charProp = IsCategory
+IsCategory = Letters / Marks / Numbers / Punctuation / Separators /
+    Symbols / Others
+Letters = %s"L" [ ( %s"l" / %s"m" / %s"o" / %s"t" / %s"u" ) ]
+Marks = %s"M" [ ( %s"c" / %s"e" / %s"n" ) ]
+Numbers = %s"N" [ ( %s"d" / %s"l" / %s"o" ) ]
+Punctuation = %s"P" [ ( %x63-66 ; 'c'-'f'
+ / %s"i" / %s"o" / %s"s" ) ]
+Separators = %s"Z" [ ( %s"l" / %s"p" / %s"s" ) ]
+Symbols = %s"S" [ ( %s"c" / %s"k" / %s"m" / %s"o" ) ]
+Others = %s"C" [ ( %s"c" / %s"f" / %s"n" / %s"o" ) ]
+*/
+
+// recursive-descent starts here
+func readRegexp(re string) (*regexpParse, error) {
+	return readRegexpWithParse(newRxParseState([]byte(re)))
+}
+
+func readRegexpWithParse(parse *regexpParse) (*regexpParse, error) {
+	return parse, readBranches(parse)
+}
+
+// branch = *piece
+func readBranches(parse *regexpParse) error {
+	for !parse.isEmpty() {
+		branch, err := readBranch(parse)
+		if (err != nil) && !errors.Is(err, errRegexpStuck) {
+			return err
+		}
+		parse.tree = append(parse.tree, branch)
+		if errors.Is(err, errRegexpEOF) {
+			return nil
+		}
+		var b rune
+		b, _ = parse.nextRune() // we already know we're not at EOF
+		if b == '|' {
+			parse.features.recordFeature(rxfOrBar)
+			continue
+		} else if b == ')' {
+			// TODO: Figure out how to work into tree
+			parse.backup1(b)
+			return nil
+		}
+		// no else, can't happen
+	}
+	return nil
+}
+
+func readBranch(parse *regexpParse) (regexpBranch, error) {
+	var branch regexpBranch
+	var err error
+	for err == nil {
+		var piece *regexpQuantifiedAtom
+		piece, err = readPiece(parse)
+		if err == nil {
+			branch = append(branch, piece)
+		}
+	}
+	if errors.Is(err, errRegexpEOF) {
+		return branch, nil
+	}
+	return nil, err
+}
+
+// piece = atom [ quantifier ]
+func readPiece(parse *regexpParse) (*regexpQuantifiedAtom, error) {
+	var err error
+	var nextQA *regexpQuantifiedAtom
+	nextQA, err = readAtom(parse)
+	if err != nil {
+		return nil, err
+	}
+	if nextQA == nil {
+		return nil, errRegexpStuck
+	}
+
+	err = readQuantifier(parse, nextQA)
+	if (err == nil) || errors.Is(err, errRegexpStuck) {
+		return nextQA, nil
+	}
+	return nil, err
+}
+
+// atom = NormalChar / charClass / ( "(" i-regexp ")" )
+func readAtom(parse *regexpParse) (*regexpQuantifiedAtom, error) {
+	var qa regexpQuantifiedAtom
+	b, err := parse.nextRune()
+	if err != nil {
+		return nil, err
+	}
+	switch {
+	case isNormalChar(b):
+		qa.runes = RuneRange{RunePair{b, b}}
+		qa.quantMin, qa.quantMax = 1, 1
+		return &qa, nil
+	case b == '.':
+		// charClass = "." / SingleCharEsc / charClassEsc / charClassExpr
+		parse.features.recordFeature(rxfDot)
+		qa.isDot = true
+		qa.quantMin, qa.quantMax = 1, 1
+		return &qa, nil
+	case b == '(':
+		parse.nest()
+		parse.features.recordFeature(rxfParenGroup)
+		newBranch := regexpBranch{}
+		qa.subtree = regexpRoot{newBranch}
+		err = readBranches(parse)
+		if (err != nil) && !errors.Is(err, errRegexpEOF) {
+			return nil, err
+		}
+		err = parse.require(')')
+		if err != nil {
+			return nil, fmt.Errorf("missing ')' at %d", parse.lastOffset())
+		}
+		parse.unNest()
+		return &qa, nil
+	case b == ')':
+		if parse.isNested() {
+			parse.backup1(b)
+			return nil, errRegexpStuck
+		} else {
+			return nil, fmt.Errorf("unbalanced ')' at %d", parse.lastOffset())
+		}
+	case b == '[':
+		parse.features.recordFeature(rxfClass)
+		err = readCharClassExpr(parse)
+		if err != nil {
+			return nil, err
+		}
+		return &qa, nil
+	case b == ']':
+		return nil, fmt.Errorf("invalid ']' at %d", parse.lastOffset())
+	case b == Escape:
+		c, err := parse.nextRune()
+		if errors.Is(err, errRegexpEOF) {
+			return nil, errors.New("'~' at end of regular expression")
+		}
+		if err != nil {
+			return nil, err
+		}
+		escaped, ok := checkSingleCharEscape(c)
+		if ok {
+			qa.runes = RuneRange{RunePair{escaped, escaped}}
+			return &qa, nil
+		}
+		if c == 'p' || c == 'P' {
+			// QA not implemented yet
+			parse.features.recordFeature(rxfProperty)
+			return &regexpQuantifiedAtom{}, readCategory(parse)
+		}
+		if bytes.ContainsRune([]byte("sSiIcCdDwW"), c) {
+			return nil, fmt.Errorf("multiple-character escape ~%c at %d", c, parse.lastOffset())
+		}
+		return nil, fmt.Errorf("invalid character '%c' after '~' at %d", c, parse.lastOffset())
+
+	case bytes.ContainsRune([]byte("?+*{"), b):
+		return nil, fmt.Errorf("invalid character '%c' at %d", b, parse.lastOffset())
+
+	default:
+		parse.backup1(b)
+		return nil, errRegexpStuck
+	}
+}
+
+// charClassExpr = "[" [ "^" ] ( "-" / CCE1 ) *CCE1 [ "-" ] "]"
+
+func readCharClassExpr(parse *regexpParse) error {
+	// starting after the "["
+	var err error
+	bypassed, err := parse.bypassOptional('^')
+	if errors.Is(err, errRegexpEOF) {
+		err = errors.New("empty character class []")
+	}
+	if err != nil {
+		return err
+	}
+	if bypassed {
+		parse.features.recordFeature(rxfNegatedClass)
+	}
+	if err = readCCE1s(parse); err != nil {
+		return err
+	}
+	_, _ = parse.bypassOptional('-') // already probed
+	if err = parse.require(']'); err != nil {
+		return err
+	}
+	return nil
+}
+
+// readCCE1s proceeds forward until the next chunk is not a CCE1
+func readCCE1s(parse *regexpParse) error {
+	first := true
+	for {
+		if err := readCCE1(parse, first); err != nil {
+			return err
+		}
+		first = false
+		r, _ := parse.nextRune() // already probed
+		parse.backup1(r)
+		if r == '-' || r == ']' {
+			return nil
+		}
+	}
+}
+
+// CCE1 = ( CCchar [ "-" CCchar ] ) / charClassEsc
+// CCchar = ( %x00-2C / %x2E-5A ; '.'-'Z'
+// / %x5E-D7FF ; skip surrogate code points
+// / %xE000-10FFFF ) / SingleCharEsc
+
+func isCCchar(r rune) bool {
+	if r <= 0x2c || (r >= 0x2e && r <= 0x5A) {
+		return true
+	}
+	if r >= 0x5e && r <= 0xd7ff {
+		return true
+	}
+	if r >= 0xe000 && r <= 0x10fff {
+		return true
+	}
+	if r == '\\' {
+		// weird but true
+		return true
+	}
+	return false
+}
+
+// CCE1 = ( CCchar [ "-" CCchar ] ) / charClassEsc
+// CCchar = ( %x00-2C / %x2E-5A ; '.'-'Z'
+// / %x5E-D7FF ; skip surrogate code points
+// / %xE000-10FFFF ) / SingleCharEsc
+
+// readCCE1 reads one instance of CCE1 token
+func readCCE1(parse *regexpParse, first bool) error {
+	// starts after [
+	r, _ := parse.nextRune() // have already probed, can't fail
+
+	var err error
+	var lo rune
+	if first && r == '-' {
+		lo = '-'
+	} else if r == Escape {
+		r, _ = parse.nextRune() // have already probed
+		if r == 'p' || r == 'P' {
+			// maybe a good category, in which case we can't participate in range, so we're done
+			// or a malformed category
+			parse.features.recordFeature(rxfProperty)
+			return readCategory(parse)
+		}
+		escaped, ok := checkSingleCharEscape(r)
+		if !ok {
+			return fmt.Errorf("invalid character '%c' after ~ at %d", r, parse.lastOffset())
+		}
+		lo = escaped
+		// we've seen a single-character escape
+	} else {
+		if !isCCchar(r) {
+			return fmt.Errorf("invalid character '%c' after [ at %d", r, parse.lastOffset())
+		}
+		lo = r
+	}
+	// either a regular character or a single-char escape, either we're done or we're looking for '-'
+	r, err = parse.nextRune()
+	if err != nil {
+		return fmt.Errorf("error in range at %d", parse.lastOffset())
+	}
+	if r != '-' {
+		// not a range, so probably looking for the next cce1
+		parse.backup1(r)
+		return nil
+	}
+	// looking at a range
+	r, err = parse.nextRune()
+	if err != nil {
+		return err
+	}
+	// might be end of range -] which is legal. Otherwise, has to be either a CChar or single-char escape
+	if r == ']' {
+		parse.backup1(r)
+		parse.backup1('-')
+		return nil
+	}
+	if r == Escape {
+		r, err = parse.nextRune()
+		if err != nil {
+			return err
+		}
+		escaped, ok := checkSingleCharEscape(r)
+		if !ok {
+			return fmt.Errorf("invalid char '%c' after - at %d", r, parse.lastOffset())
+		}
+		if lo > escaped {
+			return fmt.Errorf("invalid range %c-%c", lo, r)
+		}
+		return nil
+	}
+	if !isCCchar(r) {
+		return fmt.Errorf("invalid char '%c' after - at %d", r, parse.lastOffset())
+	}
+	if lo > r {
+		return fmt.Errorf("invalid range %c-%c", lo, r)
+	}
+	return nil
+}
+
+// catEsc = %s"\p{" charProp "}"
+// complEsc = %s"\P{" charProp "}"
+// charProp = IsCategory
+// IsCategory = Letters / Marks / Numbers / Punctuation / Separators /
+// Symbols / Others
+// Letters = %s"L" [ ( %s"l" / %s"m" / %s"o" / %s"t" / %s"u" ) ]
+// Marks = %s"M" [ ( %s"c" / %s"e" / %s"n" ) ]
+// Numbers = %s"N" [ ( %s"d" / %s"l" / %s"o" ) ]
+// Punctuation = %s"P" [ ( %x63-66 ; 'c'-'f'
+// / %s"i" / %s"o" / %s"s" ) ]
+// Separators = %s"Z" [ ( %s"l" / %s"p" / %s"s" ) ]
+// Symbols = %s"S" [ ( %s"c" / %s"k" / %s"m" / %s"o" ) ]
+// Others = %s"C" [ ( %s"c" / %s"f" / %s"n" / %s"o" ) ]
+
+var regexpCatDetails = map[rune]string{
+	'L': "ultmo",
+	'M': "nce",
+	'N': "dlo",
+	'P': "cdseifo",
+	'Z': "slp",
+	'S': "mcko",
+	'C': "cfon",
+}
+
+func readCategory(parse *regexpParse) error {
+	var err error
+	if err = parse.require('{'); err != nil {
+		return err
+	}
+	categoryInitial, err := parse.nextRune()
+	if err != nil {
+		return err
+	}
+	categoryDetail, ok := regexpCatDetails[categoryInitial]
+	if !ok {
+		return fmt.Errorf("unknown category %c at %d", categoryInitial, parse.lastOffset())
+	}
+	catDetailLetter, err := parse.nextRune()
+	if err != nil {
+		return fmt.Errorf("error in category after {%c at %d", categoryInitial, parse.lastOffset())
+	}
+	if catDetailLetter == '}' {
+		return nil
+	}
+	if !bytes.ContainsRune([]byte(categoryDetail), catDetailLetter) {
+		return fmt.Errorf("unknown category ~P{%c%c} at %d", categoryInitial, catDetailLetter, parse.lastOffset())
+	}
+	if err = parse.require('}'); err != nil {
+		return err
+	}
+	return nil
+}
+
+func readQuantifier(parse *regexpParse, qa *regexpQuantifiedAtom) error {
+	// quantifier = ( "*" / "+" / "?" ) / range-quantifier
+	// range-quantifier = "{" QuantExact [ "," [ QuantExact ] ] "}"
+	// QuantExact = 1*%x30-39 ; '0'-'9'
+	b, err := parse.nextRune()
+	if errors.Is(err, errRegexpEOF) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	switch b {
+	case '*':
+		parse.features.recordFeature(rxfStar)
+		qa.quantMin, qa.quantMax = 0, regexpQuantifierMax
+		return nil
+	case '+':
+		parse.features.recordFeature(rxfPlus)
+		qa.quantMin, qa.quantMax = 1, regexpQuantifierMax
+		return nil
+	case '?':
+		parse.features.recordFeature(rxfQM)
+		qa.quantMin, qa.quantMax = 0, 1
+		return nil
+	case '{':
+		parse.features.recordFeature(rxfRange)
+		return readRangeQuantifier(parse, qa)
+	}
+	parse.backup1(b)
+	return errRegexpStuck
+}
+
+func readRangeQuantifier(parse *regexpParse, qa *regexpQuantifiedAtom) error {
+	// after {
+	var loDigits []rune
+	b, err := parse.nextRune()
+	if err != nil {
+		return err
+	}
+	for b >= '0' && b <= '9' {
+		loDigits = append(loDigits, b)
+		b, err = parse.nextRune()
+		if err != nil {
+			return err
+		}
+	}
+	if len(loDigits) == 0 {
+		return fmt.Errorf("invalid range quantifier, expecting digits at %d", parse.lastOffset())
+	}
+	// have read some digits
+	lo, err := strconv.ParseInt(string(loDigits), 10, 32)
+	if err != nil {
+		return err
+	}
+	qa.quantMin = int(lo)
+	qa.quantMax = regexpQuantifierMax
+	switch b {
+	case '}':
+		return nil
+	case ',':
+	// no-op, good
+	default:
+		return fmt.Errorf("unexpected character %c at %d", b, parse.lastOffset())
+	}
+	// have seen digits and a comma
+	var hiDigits []rune
+	b, err = parse.nextRune()
+	if errors.Is(err, errRegexpEOF) {
+		return fmt.Errorf("incomplete range quantifier at %d", parse.lastOffset())
+	}
+	if err != nil {
+		return err
+	}
+	if b == '}' {
+		return nil
+	}
+	if b < '0' || b > '9' {
+		return fmt.Errorf("invalid character '%c' in quantifier range at %d, wanted a digit", b, parse.lastOffset())
+	}
+	for b >= '0' && b <= '9' {
+		hiDigits = append(hiDigits, b)
+		b, err = parse.nextRune()
+		if errors.Is(err, errRegexpEOF) {
+			return fmt.Errorf("incomplete range quantifier at %d", parse.lastOffset())
+		}
+		if err != nil {
+			return err
+		}
+	}
+	// have scanned digits, have to close with '}'
+	if b != '}' {
+		return fmt.Errorf("invalid character %c at %d, expected '}'", b, parse.lastOffset())
+	}
+	hi, err := strconv.ParseInt(string(hiDigits), 10, 32)
+	if err != nil {
+		return err
+	}
+	if hi < lo {
+		return fmt.Errorf("invalid range quantifier, top must be greater than bottom")
+	}
+	qa.quantMax = int(hi)
+	return nil
+}
+
+// isNormalChar - not optimized, implemented line-by-line from the production for clarity
+func isNormalChar(c rune) bool {
+	if c <= 0x27 || c == ',' || c == '-' || (c >= 0x2F && c <= 0x3E) {
+		return true
+	}
+	if c >= 0x40 && c <= 0x5A {
+		return true
+	}
+	// allow \
+	if c == 0x5c {
+		return true
+	}
+	if c >= 0x5E && c <= 0x7A {
+		return true
+	}
+	// exclude ~
+	if c >= 0x7F && c <= 0xD7FF {
+		return true
+	}
+	if c >= 0xE000 && c <= 0x10FFFF {
+		return true
+	}
+	return false
+}
+
+// checkSingleCharEscape - things that need escaping
+// SingleCharEsc = "\" ( %x28-2B ; '('-'+'
+// / "-" / "." / "?" / %x5B-5E ; '['-'^'
+// / %s"n" / %s"r" / %s"t" / %x7B-7D ; '{'-'}'
+// )
+func checkSingleCharEscape(c rune) (rune, bool) {
+	if c >= 0x28 && c <= 0x2B {
+		return c, true
+	}
+	if c == '-' || c == '.' || c == '?' || (c >= 0x5B && c <= 0x5E) {
+		return c, true
+	}
+	if c == 'n' {
+		return '\n', true
+	}
+	if c == 'r' {
+		return '\r', true
+	}
+	if c == 't' {
+		return '\t', true
+	}
+	if c >= 0x7B && c <= 0x7D {
+		return c, true
+	}
+	if c == Escape {
+		return Escape, true
+	}
+	return 0, false
+}

--- a/regexp_reader_test.go
+++ b/regexp_reader_test.go
@@ -1,0 +1,231 @@
+package quamina
+
+import (
+	"fmt"
+	"math"
+	"strings"
+	"testing"
+)
+
+// NormalChar = ( %x00-27 / "," / "-" / %x2F-3E ; '/'-'>'
+// / %x40-5A ; '@'-'Z'
+// / %x5E-7A ; '^'-'z'
+// / %x7E-D7FF ; skip surrogate code points
+// / %xE000-10FFFF )
+func TestIsNormalChar(t *testing.T) {
+	normals := []rune{
+		0, 1, 0x26, 0x27,
+		0x40, 0x41, 0x59, 0x5a, 0x5c,
+		0x5e, 0x5f, 0x79, 0x7a,
+		0x7f, 0xd7fe, 0xd7ff,
+		0xe000, 0xe001, 0x10fffe, 0x10ffff,
+	}
+	for _, normal := range normals {
+		if !isNormalChar(normal) {
+			t.Errorf("%x abnormal", normal)
+		}
+	}
+	abormals := []rune{
+		0x28, 0x2e, 0x3f,
+		0x3f, 0x5b,
+		0x5d, 0x7b,
+		0x7d, 0x7e, 0xd800,
+		0xdfff,
+	}
+	for _, abnormal := range abormals {
+		if isNormalChar(abnormal) {
+			t.Errorf("%x normal", abnormal)
+		}
+	}
+}
+
+func TestSingleCharEscape(t *testing.T) {
+	// SingleCharEsc = "\" ( %x28-2B ; '('-'+'
+	// / "-" / "." / "?" / %x5B-5E ; '['-'^'
+	// / %s"n" / %s"r" / %s"t" / %x7B-7D ; '{'-'}'
+	//)
+	sces := []rune{
+		0x28, 0x29, 0x2a, 0x2b,
+		'-', '.', '?', 0x5B, 0x5C, 0x5D, 0x5E,
+		'n', 'r', 't', 0x7B, 0x7C, 0x7D,
+		'~',
+	}
+	for _, sce := range sces {
+		_, ok := checkSingleCharEscape(sce)
+		if !ok {
+			t.Errorf("%x not sce", sce)
+		}
+	}
+	notSces := []rune{
+		0x27, 0x2C, 0x5A, 0x5F, 'j', 0x7A, 0x7F,
+	}
+	for _, notSce := range notSces {
+		_, ok := checkSingleCharEscape(notSce)
+		if ok {
+			t.Errorf("%x is sce", notSce)
+		}
+	}
+}
+
+func TestReadCCE1(t *testing.T) {
+	goods := []string{
+		`~n-~r`, "a", "ab", "a-b",
+	}
+	bads := []string{
+		"a-~P{Lu}", "~P{Lu}-x",
+	}
+	for _, good := range goods {
+		_, err := readRegexp("[" + good + "]")
+		if err != nil {
+			t.Errorf("Blecch %s", good)
+		}
+	}
+	for _, bad := range bads {
+		_, err := readRegexp("[" + bad + "]")
+		if err == nil {
+			t.Errorf("Missed bad %s", bad)
+		}
+	}
+}
+
+func TestBasicRegexpFeatureRead(t *testing.T) {
+	type fw struct {
+		rx     string
+		wanted []regexpFeature
+	}
+
+	var tfw = []fw{
+		{rx: "a.b", wanted: []regexpFeature{rxfDot}},
+		{rx: "ab*", wanted: []regexpFeature{rxfStar}},
+		{rx: "a+b", wanted: []regexpFeature{rxfPlus}},
+		{rx: "(ab)+", wanted: []regexpFeature{rxfParenGroup, rxfPlus}},
+		{rx: "zz?zz", wanted: []regexpFeature{rxfQM}},
+		{rx: "zzzz{3}", wanted: []regexpFeature{rxfRange}},
+		{rx: "zzzz{0,3}", wanted: []regexpFeature{rxfRange}},
+		{rx: "zzzz{3,}", wanted: []regexpFeature{rxfRange}},
+		{rx: "a~p{Lt}", wanted: []regexpFeature{rxfProperty}},
+		{rx: "a~P{Me}", wanted: []regexpFeature{rxfProperty}},
+		{rx: "a[fox37é]z", wanted: []regexpFeature{rxfClass}},
+		{rx: "a[-fox37é-]z", wanted: []regexpFeature{rxfClass}},
+		{rx: "a[fox33-87é]z", wanted: []regexpFeature{rxfClass}},
+		{rx: "a[^fox37é]z", wanted: []regexpFeature{rxfClass, rxfNegatedClass}},
+		{rx: "(abc)|(def)", wanted: []regexpFeature{rxfOrBar, rxfParenGroup}},
+	}
+
+	var parse *regexpParse
+	var err error
+	for _, w := range tfw {
+		fmt.Println("RX: " + w.rx)
+		parse, err = readRegexp(w.rx)
+		if err != nil {
+			t.Errorf("botch on %s: %s", w.rx, err.Error())
+		}
+		if len(w.wanted) != len(parse.features.found) {
+			t.Errorf("for %s got %d wanted %d", w.rx, len(parse.features.found), len(w.wanted))
+		} else {
+			for _, f := range w.wanted {
+				_, ok := parse.features.found[f]
+				if !ok {
+					t.Errorf("for %s missed feature %s", w.rx, f)
+				}
+			}
+		}
+	}
+	parse, _ = readRegexp("a*b")
+	unimpl := parse.features.foundUnimplemented()
+	foundStar := false
+	for _, u := range unimpl {
+		if u == rxfStar {
+			foundStar = true
+		}
+	}
+	if !foundStar {
+		t.Error("Didn't find Star")
+	}
+}
+
+func TestRegexpErrors(t *testing.T) {
+	bads := []string{
+		"~P{L",
+		"~P{L*}",
+		string([]byte{'~', 0xfe, 0xff}),
+		string([]byte{'[', 'a', 'b', 0xfe, 0xff, ']'}),
+		string([]byte{'[', 'a', '-', 0xff, ']'}),
+		string([]byte{'[', 'a', '-', '~', 0xff, ']'}),
+		string([]byte{'a', 0xff}),
+		string([]byte{'a', '{', 0xff, '}'}),
+		string([]byte{'a', '{', '2', 0xff, '}'}),
+		"a{9999999999998,9999999999999}",
+		"a{2x-3}",
+		"a{2,",
+		string([]byte{'a', '{', '2', 0xff}),
+		"a{2,r}",
+		string([]byte{'a', '{', '2', ',', 0xff}),
+		"a{2,4",
+		string([]byte{'a', '{', '2', ',', '4', 0xff}),
+		"a{2,4x",
+		"a{2,9999999999999}",
+		"abc)",
+	}
+	for _, bad := range bads {
+		_, err := readRegexp(bad)
+		if err == nil {
+			t.Error("Took " + bad)
+		}
+	}
+}
+
+func TestAddRegexpTransition(t *testing.T) {
+	// TODO: Keep adding/subtracting from this as we add features
+	goods := []string{
+		"a.",
+	}
+	bads := []string{
+		"a?", "a*", "a+", "a?",
+		"a{1,3}", "(ab)", "~p{Lu}", "[abc]", "[^abc]", "ab|cd",
+	}
+	template := `{"a":[{"regexp": "FOO"}]}`
+	cm := newCoreMatcher()
+	for _, good := range goods {
+		pat := strings.Replace(template, "FOO", good, 10)
+		err := cm.addPattern("foo", pat)
+		if err != nil {
+			t.Errorf("thinks it found unimplemented feature in /%s/", good)
+		}
+	}
+	for _, bad := range bads {
+		pat := strings.Replace(template, "FOO", bad, 10)
+		err := cm.addPattern("foo", pat)
+		if err == nil {
+			t.Errorf("missed unimplemented feature in /%s/", bad)
+		}
+	}
+}
+
+func TestUniquePaths(t *testing.T) {
+	uniques := make(map[string]bool)
+	size := int(17 * math.Pow(2.0, 16))
+	fmt.Printf("size: %d\n", size)
+	var i rune
+	for i = 0; i < rune(size); i++ {
+		buf, err := runeToUTF8(i)
+		if err != nil {
+			continue
+		}
+		var str string
+		if len(buf) > 1 {
+			str = string(buf[:len(buf)-1])
+		}
+		uniques[str] = true
+	}
+	fmt.Printf("unique: %d\n", len(uniques))
+}
+
+func TestRegexpReader(t *testing.T) {
+	pat := `{"a":[{"regexp": "a.b"}]}`
+	cm := newCoreMatcher()
+	err := cm.addPattern("x", pat)
+	if err != nil {
+		t.Error("ap: " + err.Error())
+	}
+}

--- a/regexp_samples_test.go
+++ b/regexp_samples_test.go
@@ -1,0 +1,5450 @@
+package quamina
+
+import (
+	"testing"
+)
+
+// This file produced by processing a set of XSD regexp syntax samples by Michael Kay
+// from the repo https://github.com/qt4cg/xslt40-test - thanks to Michael!
+// The code may be found in codegen/qtest-main.not-go. It is fairly horrible and my assumption
+// is that it will never be run again; there is plenty of room for more regexp-related testing
+// but I think as much benefit has been extracted from this sample set as is reasonable to expect.
+
+type regexpSample struct {
+	regex     string
+	matches   []string
+	nomatches []string
+	valid     bool
+}
+
+func TestRegexpSamplesExist(t *testing.T) {
+	if len(regexpSamples) == 0 {
+		t.Error("no samples")
+	}
+}
+
+// test-case numbers are off by one, i.e. the first one below is actually for regex-syntax-0001
+var regexpSamples = []regexpSample{
+	//    <test-case name="regex-syntax-0002">
+	{
+		regex:     "",
+		matches:   []string{"", ""},
+		nomatches: []string{"a", " ", "\r", "	", "\n"},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0003">
+	{
+		regex:     "a",
+		matches:   []string{"a"},
+		nomatches: []string{"aa", "b", ""},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0004">
+	{
+		regex:     "a|a",
+		matches:   []string{"a"},
+		nomatches: []string{"aa", "b", ""},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0005">
+	{
+		regex:     "a|b",
+		matches:   []string{"a", "b"},
+		nomatches: []string{"aa", "bb", "ab", ""},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0006">
+	{
+		regex:     "ab",
+		matches:   []string{"ab"},
+		nomatches: []string{"a", "b", "aa", "bb", ""},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0007">
+	{
+		regex:     "a|b|a|c|b|d|a",
+		matches:   []string{"a", "b", "c", "d"},
+		nomatches: []string{"aa", "ac", "e"},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0008">
+	{
+		regex:     "       a|b      ",
+		matches:   []string{"       a"},
+		nomatches: []string{""},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0009">
+	{
+		regex:     "ab?c",
+		matches:   []string{"ac", "abc"},
+		nomatches: []string{"a", "ab", "bc", ""},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0010">
+	{
+		regex:     "abc?",
+		matches:   []string{"ab", "abc"},
+		nomatches: []string{"a", "bc", "abcc", ""},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0011">
+	{
+		regex:     "ab+c",
+		matches:   []string{"abc", "abbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbc"},
+		nomatches: []string{"ac", "bbbc", "abbb", ""},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0012">
+	{
+		regex:     "abc+",
+		matches:   []string{"abc", "abccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"},
+		nomatches: []string{"a", "ab", "abcd"},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0013">
+	{
+		regex:     "ab*c",
+		matches:   []string{"abc", "abbbbbbbc", "ac"},
+		nomatches: []string{"a", "ab", "bc", "c", "abcb", ""},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0014">
+	{
+		regex:     "abc*",
+		matches:   []string{"abc", "ab", "abccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"},
+		nomatches: []string{"a", "abcd", "abbc", ""},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0015">
+	{
+		regex:     "a?b+c*",
+		matches:   []string{"b", "ab", "bcccccc", "abc", "abbbc"},
+		nomatches: []string{"aabc", "a", "c", "ac", ""},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0016">
+	{
+		regex:     "(ab+c)a?~?~??",
+		matches:   []string{"abc?", "abbbc??", "abca??", "abbbbca?"},
+		nomatches: []string{"ac??", "bc??", "abc", "abc???"},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0017">
+	{
+		regex: "?a",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0018">
+	{
+		regex: "+a",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0019">
+	{
+		regex: "*a",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0020">
+	{
+		regex: "{1}a",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0021">
+	{
+		regex:     "a{0}",
+		matches:   []string{"", ""},
+		nomatches: []string{"a"},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0022">
+	{
+		regex: "a{2,1}",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0023">
+	{
+		regex: "a{1,0}",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0024">
+	{
+		regex:     "((ab){2})?",
+		matches:   []string{"abab", ""},
+		nomatches: []string{"a", "ab", "ababa", "abababab"},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0025">
+	{
+		regex:     "(a{2})+",
+		matches:   []string{"aa", "aaaa", "aaaaaaaaaaaaaaaaaaaa"},
+		nomatches: []string{"", "a", "a2", "aaa"},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0026">
+	{
+		regex:     "(a{2})*",
+		matches:   []string{"", "aa", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"},
+		nomatches: []string{"a", "aaa", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0027">
+	{
+		regex:     "ab{2}c",
+		matches:   []string{"\"xs:"},
+		nomatches: []string{"e=\"go\"/>\n      "},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0028">
+	{
+		regex:     "abc{2}",
+		matches:   []string{"abcc"},
+		nomatches: []string{"abc", "abccc", ""},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0029">
+	{
+		regex:     "a*b{2,4}c{0}",
+		matches:   []string{"aaabbb", "bb", "bbb", "bbbb"},
+		nomatches: []string{"ab", "abbc", "bbc", "abbbbb", ""},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0030">
+	{
+		regex:     "((ab)(ac){0,2})?",
+		matches:   []string{"ab", "abac", "abacac"},
+		nomatches: []string{"ac", "abacacac", "abaca", "abab", "abacabac"},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0031">
+	{
+		regex: "(a~sb){0,2}",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0032">
+	{
+		regex:     "(ab){2,}",
+		matches:   []string{"abab", "ababab", "ababababababababababababababababababababababababababababababababab"},
+		nomatches: []string{"ab", "ababa", "ababaa", "ababababa", "abab abab", ""},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0033">
+	{
+		regex: "a{,2}",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0034">
+	{
+		regex: "(ab){2,0}",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0035">
+	{
+		regex:     "(ab){0,0}",
+		matches:   []string{""},
+		nomatches: []string{"a", "ab"},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0036">
+	{
+		regex:     "a{0,1}b{1,2}c{2,3}",
+		matches:   []string{"abcc", "abccc", "abbcc", "abbccc", "bbcc", "bbccc"},
+		nomatches: []string{"aabcc", "bbbcc", "acc", "aabcc", "abbc", "abbcccc"},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0037">
+	{
+		regex:     "(((((boy)|(girl))[0-1][x-z]{2})?)|(man|woman)[0-1]?[y|n])*",
+		matches:   []string{"", "boy0xx", "woman1y", "girl1xymany", "boy0xxwoman1ygirl1xymany", "boy0xxwoman1ygirl1xymanyboy0xxwoman1ygirl1xymany"},
+		nomatches: []string{"boy0xxwoman1ygirl1xyman", "boyxx"},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0038">
+	{
+		regex: "((a)",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0039">
+	{
+		regex: "(a))",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0040">
+	{
+		regex: "ab|(d))",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0041">
+	{
+		regex: "((a*(b*)((a))*(a))))",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0042">
+	{
+		regex: "~",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0043">
+	{
+		regex: "?",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0044">
+	{
+		regex: "*",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0045">
+	{
+		regex: "+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0046">
+	{
+		regex: "(",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0047">
+	{
+		regex: ")",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0048">
+	{
+		regex:     "|",
+		matches:   []string{""},
+		nomatches: []string{""},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0049">
+	{
+		regex: "[",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0050">
+	{
+		regex:     "~.~~~?~*~+~{~}~[~]~(~)~|",
+		matches:   []string{".~?*+{}[]()|"},
+		nomatches: []string{""},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0051">
+	{
+		regex:     "(([~.~~~?~*~+~{~}~[~]~(~)~|]?)*)+",
+		matches:   []string{" <description>see regex-syntax-0001<"},
+		nomatches: []string{""},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0052">
+	{
+		regex:     "[^2-9a-x]{2}",
+		matches:   []string{"1z"},
+		nomatches: []string{"1x"},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0053">
+	{
+		regex: "[^~s]{3}",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0054">
+	{
+		regex:     "[^@]{0,2}",
+		matches:   []string{"", "a", "ab", " a"},
+		nomatches: []string{"@"},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0055">
+	{
+		regex:     "[^-z]+",
+		matches:   []string{""},
+		nomatches: []string{"aaz", "a-z"},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0056">
+	{
+		regex: "[a-d-[b-c]]",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0056a">
+	{
+		regex: "[^a-d-b-c]",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0057">
+	{
+		regex: "[^a-d-b-c]",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0058">
+	{
+		regex:     "[a-~}]+",
+		matches:   []string{"abcxyz}"},
+		nomatches: []string{""},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0059">
+	{
+		regex: "[a-b-[0-9]]+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0060">
+	{
+		regex: "[a-c-[^a-c]]",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0061">
+	{
+		regex: "[a-z-[^a]]",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0062">
+	{
+		regex: "[^~p{IsBasicLatin}]+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0063">
+	{
+		regex: "[^~p{IsBasicLatin}]*",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0064">
+	{
+		regex: "[^~P{IsBasicLatin}]",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0065">
+	{
+		regex:     "[^~?]",
+		matches:   []string{""},
+		nomatches: []string{"?"},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0066">
+	{
+		regex:     "([^~?])*",
+		matches:   []string{"a+*abc"},
+		nomatches: []string{""},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0067">
+	{
+		regex: "~c[^~d]~c",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0068">
+	{
+		regex: "~c[^~s]~c",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0069">
+	{
+		regex:     "[^~^a]",
+		matches:   []string{""},
+		nomatches: []string{"^", "a"},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0070">
+	{
+		regex:     "[a-abc]{3}",
+		matches:   []string{"abc"},
+		nomatches: []string{""},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0071">
+	{
+		regex:     "[a-~}-]+",
+		matches:   []string{"}-"},
+		nomatches: []string{""},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0072">
+	{
+		regex: "[a--b]",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0073">
+	{
+		regex: "[^[a-b]]",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0074">
+	{
+		regex:     "[a]",
+		matches:   []string{""},
+		nomatches: []string{"b", ""},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0075">
+	{
+		regex:     "[1-3]{1,4}",
+		matches:   []string{"123"},
+		nomatches: []string{""},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0076">
+	{
+		regex:     "[a-a]",
+		matches:   []string{"a"},
+		nomatches: []string{"b"},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0077">
+	{
+		regex:     "[0-z]*",
+		matches:   []string{"1234567890:;<=>?@Azaz"},
+		nomatches: []string{"{", "/"},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0078">
+	{
+		regex:     "[~n]",
+		matches:   []string{""},
+		nomatches: []string{""},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0079">
+	{
+		regex:     "[~t]",
+		matches:   []string{""},
+		nomatches: []string{""},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0080">
+	{
+		regex:     "[~~~|~.~?~*~+~(~)~{~}~-~[~]~^]*",
+		matches:   []string{"~|.?*+(){}-[]^"},
+		nomatches: []string{""},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0081">
+	{
+		regex:     "[^a-z^]",
+		matches:   []string{""},
+		nomatches: []string{""},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0082">
+	{
+		regex:     "[\\-~{^]",
+		matches:   []string{""},
+		nomatches: []string{""},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0083">
+	{
+		regex: "[~C~?a-c~?]+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0084">
+	{
+		regex: "[~c~?a-c~?]+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0085">
+	{
+		regex: "[~D~?a-c~?]+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0086">
+	{
+		regex: "[~S~?a-c~?]+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0086a">
+	{
+		regex: "[a-c-1-4x-z-7-9]*",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0087">
+	{
+		regex: "[a-c-1-4x-z-7-9]*",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0088">
+	{
+		regex: "[a-\\]",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0089">
+	{
+		regex: "[a-~[]",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0090">
+	{
+		regex:     "[~*a]*",
+		matches:   []string{"a*a****aaaaa*"},
+		nomatches: []string{""},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0091">
+	{
+		regex: "[a-;]",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0092">
+	{
+		regex:     "[1-~]]+",
+		matches:   []string{"1]"},
+		nomatches: []string{"0", "^"},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0093">
+	{
+		regex:     "[=->]",
+		matches:   []string{"=", ">"},
+		nomatches: []string{"~?"},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0094">
+	{
+		regex: "[>-=]",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0095">
+	{
+		regex:     "[@]",
+		matches:   []string{"@"},
+		nomatches: []string{"a"},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0096">
+	{
+		regex:     "[࿿]",
+		matches:   []string{"࿿"},
+		nomatches: []string{""},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0097">
+	{
+		regex:     "[𐀀]",
+		matches:   []string{"𐀀"},
+		nomatches: []string{"𐀁"},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0098">
+	{
+		regex: "[~]",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0099">
+	{
+		regex:     "[~~~[~]]{0,3}",
+		matches:   []string{"as=\"xs:string\" select=\"'~|."},
+		nomatches: []string{"~[][", "~]~]", "[][]"},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0100">
+	{
+		regex:     "[-]",
+		matches:   []string{"-"},
+		nomatches: []string{""},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0101">
+	{
+		regex:     "[-a]+",
+		matches:   []string{"a--aa---"},
+		nomatches: []string{""},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0102">
+	{
+		regex:     "[a-]*",
+		matches:   []string{"a--aa---"},
+		nomatches: []string{""},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0102a">
+	{
+		regex: "[a-a-x-x]+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0103">
+	{
+		regex: "[a-a-x-x]+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0104">
+	{
+		regex:     "[~n~r~t~~~|~.~-~^~?~*~+~{~}~[~]~(~)]*",
+		matches:   []string{"~|.-^?*+[]{}()*[[]{}}))\n\r		\n\n\r*()"},
+		nomatches: []string{""},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0105">
+	{
+		regex:     "[a~*]*",
+		matches:   []string{"a**", "aa*", "a"},
+		nomatches: []string{""},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0106">
+	{
+		regex:     "[(a~?)?]+",
+		matches:   []string{"a?", "a?a?a?", "a", "a??", "aa?"},
+		nomatches: []string{""},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0107">
+	{
+		regex:     "~~t",
+		matches:   []string{"~t"},
+		nomatches: []string{"t", "~~t", "	"},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0108">
+	{
+		regex:     "~~n",
+		matches:   []string{"~n"},
+		nomatches: []string{"n", "~~n", "\n"},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0109">
+	{
+		regex:     "~~r",
+		matches:   []string{"~r"},
+		nomatches: []string{"r", "~~r", "\r"},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0110">
+	{
+		regex:     "~n",
+		matches:   []string{""},
+		nomatches: []string{""},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0111">
+	{
+		regex:     "~t",
+		matches:   []string{""},
+		nomatches: []string{""},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0112">
+	{
+		regex:     "~~",
+		matches:   []string{"~"},
+		nomatches: []string{""},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0113">
+	{
+		regex:     "~|",
+		matches:   []string{"|"},
+		nomatches: []string{""},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0114">
+	{
+		regex:     "~.",
+		matches:   []string{"."},
+		nomatches: []string{""},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0115">
+	{
+		regex:     "~-",
+		matches:   []string{"-"},
+		nomatches: []string{""},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0116">
+	{
+		regex:     "~^",
+		matches:   []string{"^"},
+		nomatches: []string{""},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0117">
+	{
+		regex:     "~?",
+		matches:   []string{"?"},
+		nomatches: []string{""},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0118">
+	{
+		regex:     "~*",
+		matches:   []string{"*"},
+		nomatches: []string{""},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0119">
+	{
+		regex:     "~+",
+		matches:   []string{"+"},
+		nomatches: []string{""},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0120">
+	{
+		regex:     "~{",
+		matches:   []string{"{"},
+		nomatches: []string{""},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0121">
+	{
+		regex:     "~}",
+		matches:   []string{"}"},
+		nomatches: []string{""},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0122">
+	{
+		regex:     "~(",
+		matches:   []string{"("},
+		nomatches: []string{""},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0123">
+	{
+		regex:     "~)",
+		matches:   []string{")"},
+		nomatches: []string{""},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0124">
+	{
+		regex:     "~[",
+		matches:   []string{"["},
+		nomatches: []string{""},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0125">
+	{
+		regex:     "~]",
+		matches:   []string{"\""},
+		nomatches: []string{""},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0126">
+	{
+		regex:     "~n~~~r~|~t~.~-~^~?~*~+~{~}~(~)~[~]",
+		matches:   []string{""},
+		nomatches: []string{"\n~\r|	.-^?*+{}()[", "~\r|	.-^?*+{}()[]", "\n~\r|	-^?*+{}()[]"},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0127">
+	{
+		regex:     "~n~na~n~nb~n~n",
+		matches:   []string{""},
+		nomatches: []string{"\n\na\n\nb\n", "\na\n\nb\n\n", "\n\na\n\n\n\n", "\n\na\n\r\nb\n\n"},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0128">
+	{
+		regex:     "~r~ra~r~rb~r~r",
+		matches:   []string{"\r\ra\r\rb\r\r"},
+		nomatches: []string{"\r\ra\r\rb\r", "\ra\r\rb\r\r", "\r\ra\r\r\r\r", "\r\ra\r\n\rb\r\r"},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0129">
+	{
+		regex:     "~t~ta~t~tb~t~t",
+		matches:   []string{""},
+		nomatches: []string{"		a		b	", "	a		b		", "		a				", "		a			b		"},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0130">
+	{
+		regex:     "a~r~nb",
+		matches:   []string{"a\r\nb"},
+		nomatches: []string{""},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0131">
+	{
+		regex:     "~n~ra~n~rb",
+		matches:   []string{"\"/>\n      </test>\n    "},
+		nomatches: []string{""},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0132">
+	{
+		regex:     "~ta~tb~tc~t",
+		matches:   []string{"	a	b	c	"},
+		nomatches: []string{""},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0133">
+	{
+		regex:     "~na~nb~nc~n",
+		matches:   []string{"\na\nb\nc\n"},
+		nomatches: []string{""},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0134">
+	{
+		regex: "(~t|~s)a(~r~n|~r|~n|~s)+(~s|~t)b(~s|~r~n|~r|~n)*",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0135">
+	{
+		regex:     "~~c",
+		matches:   []string{"~c"},
+		nomatches: []string{"~p{_xmlC}", "~~c", "~~"},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0136">
+	{
+		regex:     "~~.,~~s,~~S,~~i,~~I,~~c,~~C,~~d,~~D,~~w,~~W",
+		matches:   []string{"~.,~s,~S,~i,~I,~c,~C,~d,~D,~w,~W"},
+		nomatches: []string{""},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0137">
+	{
+		regex:     "~~.*,~~s*,~~S*,~~i*,~~I?,~~c+,~~C+,~~d{0,3},~~D{1,1000},~~w*,~~W+",
+		matches:   []string{"ram name=\"regex\" as=\"xs:string\" select=\"'~p{Lm}*'\"/>\n         <pa"},
+		nomatches: []string{""},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0138">
+	{
+		regex:     "[~p{L}*]{0,2}",
+		matches:   []string{"aX"},
+		nomatches: []string{"aBC"},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0139">
+	{
+		regex:     "(~p{Ll}~p{Cc}~p{Nd})*",
+		matches:   []string{""},
+		nomatches: []string{" "},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0140">
+	{
+		regex:     "~p{L}*",
+		matches:   []string{""},
+		nomatches: []string{"⃝"},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0141">
+	{
+		regex:     "~p{Lu}*",
+		matches:   []string{"A𝞨"},
+		nomatches: []string{"a"},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0142">
+	{
+		regex:     "~p{Ll}*",
+		matches:   []string{"a𝟉"},
+		nomatches: []string{"ǅ"},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0143">
+	{
+		regex:     "~p{Lt}*",
+		matches:   []string{"ǅῼ"},
+		nomatches: []string{"ʰ"},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0144">
+	{
+		regex:     "~p{Lm}*",
+		matches:   []string{"<created by=\"Mi"},
+		nomatches: []string{"ntax\"/>"},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0145">
+	{
+		regex:     "~p{Lo}*",
+		matches:   []string{"א𪘀"},
+		nomatches: []string{"ً"},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0146">
+	{
+		regex:     "~p{M}*",
+		matches:   []string{"ً𝆭ः𝅲ः𝅲⃝⃝⃠"},
+		nomatches: []string{"ǅ"},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0147">
+	{
+		regex:     "~p{Mn}*",
+		matches:   []string{"ً𝆭"},
+		nomatches: []string{"ः"},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0148">
+	{
+		regex:     "~p{Mc}*",
+		matches:   []string{"ः𝅲"},
+		nomatches: []string{"⃝"},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0149">
+	{
+		regex:     "~p{Me}*",
+		matches:   []string{"⃝⃠"},
+		nomatches: []string{"０"},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0150">
+	{
+		regex:     "~p{N}*",
+		matches:   []string{"０𝟿𐍊𐍊〥²²𐌣"},
+		nomatches: []string{"ः"},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0151">
+	{
+		regex:     "~p{Nd}*",
+		matches:   []string{"０𝟿"},
+		nomatches: []string{"𐍊"},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0152">
+	{
+		regex:     "~p{Nl}*",
+		matches:   []string{"𐍊〥"},
+		nomatches: []string{"²"},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0153">
+	{
+		regex:     "~p{No}*",
+		matches:   []string{"²𐌣"},
+		nomatches: []string{"‿"},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0154">
+	{
+		regex:     "~p{P}*",
+		matches:   []string{"‿･〜〜－〝〝｢〞〞｣««‹»»›¿¿､"},
+		nomatches: []string{"²"},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0155">
+	{
+		regex:     "~p{Pc}*",
+		matches:   []string{""},
+		nomatches: []string{"〜"},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0156">
+	{
+		regex:     "~p{Pd}*",
+		matches:   []string{"〜－"},
+		nomatches: []string{"〝"},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0157">
+	{
+		regex:     "~p{Ps}*",
+		matches:   []string{"  <environment r"},
+		nomatches: []string{" as=\"xs:"},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0158">
+	{
+		regex:     "~p{Pe}*",
+		matches:   []string{"〞｣"},
+		nomatches: []string{"«"},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0159">
+	{
+		regex:     "~p{Pi}*",
+		matches:   []string{"«‹"},
+		nomatches: []string{"»"},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0160">
+	{
+		regex:     "~p{Pf}*",
+		matches:   []string{"»›"},
+		nomatches: []string{"¿"},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0161">
+	{
+		regex:     "~p{Po}*",
+		matches:   []string{"¿､"},
+		nomatches: []string{" "},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0162">
+	{
+		regex:     "~p{Z}*",
+		matches:   []string{" 　    "},
+		nomatches: []string{"¿"},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0163">
+	{
+		regex:     "~p{Zs}*",
+		matches:   []string{" 　"},
+		nomatches: []string{" "},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0164">
+	{
+		regex:     "~p{Zl}*",
+		matches:   []string{">\n      "},
+		nomatches: []string{"m name=\""},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0165">
+	{
+		regex:     "~p{Zp}*",
+		matches:   []string{" "},
+		nomatches: []string{"⁄"},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0166">
+	{
+		regex:     "~p{S}*",
+		matches:   []string{"⁄￢₠₠￦゛゛￣㆐㆐𝇝"},
+		nomatches: []string{" "},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0167">
+	{
+		regex:     "~p{Sm}*",
+		matches:   []string{"⁄￢"},
+		nomatches: []string{"₠"},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0168">
+	{
+		regex:     "~p{Sc}*",
+		matches:   []string{"₠￦"},
+		nomatches: []string{"゛"},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0169">
+	{
+		regex:     "~p{Sk}*",
+		matches:   []string{"゛￣"},
+		nomatches: []string{"㆐"},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0170">
+	{
+		regex:     "~p{So}*",
+		matches:   []string{"㆐𝇝"},
+		nomatches: []string{""},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0171">
+	{
+		regex:     "~p{C}*",
+		matches:   []string{""},
+		nomatches: []string{"₠"},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0172">
+	{
+		regex:     "~p{Cc}*",
+		matches:   []string{""},
+		nomatches: []string{"܏"},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0173">
+	{
+		regex:     "~p{Cf}*",
+		matches:   []string{"܏󠁸"},
+		nomatches: []string{""},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0174">
+	{
+		regex:     "(~p{Co})*",
+		matches:   []string{"􀀀󰀀󿿽􏿽"},
+		nomatches: []string{""},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0175">
+	{
+		regex:     "~p{Co}*",
+		matches:   []string{""},
+		nomatches: []string{"⁄"},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0176">
+	{
+		regex:     "~p{Cn}*",
+		matches:   []string{""},
+		nomatches: []string{""},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0177">
+	{
+		regex:     "~P{L}*",
+		matches:   []string{"_", "⃝"},
+		nomatches: []string{"aAbB", "A𝞨aa𝟉ǅǅῼʰʰﾟאא𪘀"},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0178">
+	{
+		regex:     "[~P{L}*]{0,2}",
+		matches:   []string{"", "#$"},
+		nomatches: []string{"!$#", "A"},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0179">
+	{
+		regex:     "~P{Lu}*",
+		matches:   []string{"a"},
+		nomatches: []string{"A𝞨"},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0180">
+	{
+		regex:     "~P{Ll}*",
+		matches:   []string{"ǅ"},
+		nomatches: []string{"a𝟉"},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0181">
+	{
+		regex:     "~P{Lt}*",
+		matches:   []string{"ʰ"},
+		nomatches: []string{"ǅῼ"},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0182">
+	{
+		regex:     "~P{Lm}*",
+		matches:   []string{"א"},
+		nomatches: []string{"ʰﾟ"},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0183">
+	{
+		regex:     "~P{Lo}*",
+		matches:   []string{"ً"},
+		nomatches: []string{"א𪘀"},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0184">
+	{
+		regex:     "~P{M}*",
+		matches:   []string{"gex-syn"},
+		nomatches: []string{"12-11-07\"/>\n      <environment ref=\"regex-syntax\"/>\n      <test>\n       "},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0185">
+	{
+		regex:     "~P{Mn}*",
+		matches:   []string{"ः𝅲"},
+		nomatches: []string{"ً𝆭"},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0186">
+	{
+		regex:     "~P{Mc}*",
+		matches:   []string{"⃝"},
+		nomatches: []string{"ः𝅲"},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0187">
+	{
+		regex:     "~P{Me}*",
+		matches:   []string{"０"},
+		nomatches: []string{"⃝⃠"},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0188">
+	{
+		regex:     "~P{N}*",
+		matches:   []string{"ः"},
+		nomatches: []string{"０𝟿𐍊𐍊〥²²𐌣"},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0189">
+	{
+		regex:     "~P{Nd}*",
+		matches:   []string{"𐍊"},
+		nomatches: []string{"０𝟿"},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0190">
+	{
+		regex:     "~P{Nl}*",
+		matches:   []string{"²"},
+		nomatches: []string{"𐍊〥"},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0191">
+	{
+		regex:     "~P{No}*",
+		matches:   []string{"     <de"},
+		nomatches: []string{"²𐌣"},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0192">
+	{
+		regex:     "~P{P}*",
+		matches:   []string{"²"},
+		nomatches: []string{"‿･〜〜－〝〝｢〞〞｣««‹»»›¿¿､"},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0193">
+	{
+		regex:     "~P{Pc}*",
+		matches:   []string{"〜"},
+		nomatches: []string{"‿･"},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0194">
+	{
+		regex:     "~P{Pd}*",
+		matches:   []string{"〝"},
+		nomatches: []string{"〜－"},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0195">
+	{
+		regex:     "~P{Ps}*",
+		matches:   []string{"〞"},
+		nomatches: []string{"〝｢"},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0196">
+	{
+		regex:     "~P{Pe}*",
+		matches:   []string{"«"},
+		nomatches: []string{"〞｣"},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0197">
+	{
+		regex:     "~P{Pi}*",
+		matches:   []string{"»"},
+		nomatches: []string{"«‹"},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0198">
+	{
+		regex:     "~P{Pf}*",
+		matches:   []string{"¿"},
+		nomatches: []string{"»›"},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0199">
+	{
+		regex:     "~P{Po}*",
+		matches:   []string{" "},
+		nomatches: []string{"¿､"},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0200">
+	{
+		regex:     "~P{Z}*",
+		matches:   []string{"¿"},
+		nomatches: []string{" 　    "},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0201">
+	{
+		regex:     "~P{Zs}*",
+		matches:   []string{" "},
+		nomatches: []string{" 　"},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0202">
+	{
+		regex:     "~P{Zl}*",
+		matches:   []string{" "},
+		nomatches: []string{" "},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0203">
+	{
+		regex:     "~P{Zp}*",
+		matches:   []string{"⁄"},
+		nomatches: []string{" "},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0204">
+	{
+		regex:     "~P{S}*",
+		matches:   []string{" <descri"},
+		nomatches: []string{"Michael Kay\" on=\"2012-11-07\"/>\n      <environment ref=\"regex-syntax\"/>\n      <test>\n     "},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0205">
+	{
+		regex:     "~P{Sm}*",
+		matches:   []string{"₠"},
+		nomatches: []string{"⁄￢"},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0206">
+	{
+		regex:     "~P{Sc}*",
+		matches:   []string{"゛"},
+		nomatches: []string{"₠￦"},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0207">
+	{
+		regex:     "~P{Sk}*",
+		matches:   []string{"㆐"},
+		nomatches: []string{"゛￣"},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0208">
+	{
+		regex:     "~P{So}*",
+		matches:   []string{""},
+		nomatches: []string{"㆐𝇝"},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0209">
+	{
+		regex:     "~P{C}*",
+		matches:   []string{"₠"},
+		nomatches: []string{"	܏܏󠁸􀀀󰀀󿿽􏿽"},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0210">
+	{
+		regex:     "~P{Cc}*",
+		matches:   []string{"܏"},
+		nomatches: []string{""},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0211">
+	{
+		regex:     "~P{Cf}*",
+		matches:   []string{""},
+		nomatches: []string{"܏󠁸"},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0212">
+	{
+		regex:     "~P{Co}*",
+		matches:   []string{"⁄"},
+		nomatches: []string{"􀀀󰀀󿿽􏿽"},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0213">
+	{
+		regex: "~p{~~L}",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0214">
+	{
+		regex:     "~~~p{L}*",
+		matches:   []string{"~a"},
+		nomatches: []string{"a"},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0215">
+	{
+		regex: "~p{Is}",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0216">
+	{
+		regex: "~P{Is}",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0217">
+	{
+		regex: "~p{IsaA0-a9}",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0218">
+	{
+		regex: "~p{IsBasicLatin}+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0219">
+	{
+		regex: "~p{IsLatin-1Supplement}+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0220">
+	{
+		regex: "~p{IsLatinExtended-A}+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0221">
+	{
+		regex: "~p{IsLatinExtended-B}+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0222">
+	{
+		regex: "~p{IsIPAExtensions}+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0223">
+	{
+		regex: "~p{IsSpacingModifierLetters}+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0224">
+	{
+		regex: "~p{IsArmenian}+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0225">
+	{
+		regex: "~p{IsHebrew}+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0226">
+	{
+		regex: "~p{IsArabic}+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0227">
+	{
+		regex: "~p{IsSyriac}+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0228">
+	{
+		regex: "~p{IsThaana}+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0229">
+	{
+		regex: "~p{IsDevanagari}+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0230">
+	{
+		regex: "~p{IsBengali}+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0231">
+	{
+		regex: "~p{IsGurmukhi}+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0232">
+	{
+		regex: "~p{IsGujarati}+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0233">
+	{
+		regex: "~p{IsOriya}+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0234">
+	{
+		regex: "~p{IsTamil}+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0235">
+	{
+		regex: "~p{IsTelugu}+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0236">
+	{
+		regex: "~p{IsKannada}+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0237">
+	{
+		regex: "~p{IsMalayalam}+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0238">
+	{
+		regex: "~p{IsSinhala}+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0239">
+	{
+		regex: "~p{IsThai}+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0240">
+	{
+		regex: "~p{IsLao}+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0241">
+	{
+		regex: "~p{IsTibetan}+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0242">
+	{
+		regex: "~p{IsMyanmar}+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0243">
+	{
+		regex: "~p{IsGeorgian}+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0244">
+	{
+		regex: "~p{IsHangulJamo}+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0245">
+	{
+		regex: "~p{IsEthiopic}+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0246">
+	{
+		regex: "~p{IsCherokee}+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0247">
+	{
+		regex: "~p{IsUnifiedCanadianAboriginalSyllabics}+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0248">
+	{
+		regex: "~p{IsOgham}+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0249">
+	{
+		regex: "~p{IsRunic}+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0250">
+	{
+		regex: "~p{IsKhmer}+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0251">
+	{
+		regex: "~p{IsMongolian}+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0252">
+	{
+		regex: "~p{IsLatinExtendedAdditional}+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0253">
+	{
+		regex: "~p{IsGreekExtended}+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0254">
+	{
+		regex: "~p{IsGeneralPunctuation}+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0255">
+	{
+		regex: "~p{IsSuperscriptsandSubscripts}+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0256">
+	{
+		regex: "~p{IsCurrencySymbols}+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0257">
+	{
+		regex: "~p{IsCombiningDiacriticalMarksforSymbols}+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0258">
+	{
+		regex: "~p{IsLetterlikeSymbols}+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0259">
+	{
+		regex: "~p{IsNumberForms}+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0260">
+	{
+		regex: "~p{IsArrows}+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0261">
+	{
+		regex: "~p{IsMathematicalOperators}+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0262">
+	{
+		regex: "~p{IsMiscellaneousTechnical}+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0263">
+	{
+		regex: "~p{IsControlPictures}+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0264">
+	{
+		regex: "~p{IsOpticalCharacterRecognition}+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0265">
+	{
+		regex: "~p{IsEnclosedAlphanumerics}+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0266">
+	{
+		regex: "~p{IsBoxDrawing}+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0267">
+	{
+		regex: "~p{IsBlockElements}+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0268">
+	{
+		regex: "~p{IsGeometricShapes}+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0269">
+	{
+		regex: "~p{IsMiscellaneousSymbols}+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0270">
+	{
+		regex: "~p{IsDingbats}+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0271">
+	{
+		regex: "~p{IsBraillePatterns}+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0272">
+	{
+		regex: "~p{IsCJKRadicalsSupplement}+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0273">
+	{
+		regex: "~p{IsKangxiRadicals}+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0274">
+	{
+		regex: "~p{IsIdeographicDescriptionCharacters}+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0275">
+	{
+		regex: "~p{IsCJKSymbolsandPunctuation}+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0276">
+	{
+		regex: "~p{IsHiragana}+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0277">
+	{
+		regex: "~p{IsKatakana}+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0278">
+	{
+		regex: "~p{IsBopomofo}+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0279">
+	{
+		regex: "~p{IsHangulCompatibilityJamo}+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0280">
+	{
+		regex: "~p{IsKanbun}+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0281">
+	{
+		regex: "~p{IsBopomofoExtended}+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0282">
+	{
+		regex: "~p{IsEnclosedCJKLettersandMonths}+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0283">
+	{
+		regex: "~p{IsCJKCompatibility}+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0284">
+	{
+		regex: "~p{IsCJKUnifiedIdeographsExtensionA}+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0285">
+	{
+		regex: "~p{IsCJKUnifiedIdeographs}+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0286">
+	{
+		regex: "~p{IsYiSyllables}+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0287">
+	{
+		regex: "~p{IsYiRadicals}+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0288">
+	{
+		regex: "~p{IsHangulSyllables}+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0288a">
+	{
+		regex: "~p{IsPrivateUseArea}+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0288b">
+	{
+		regex: "~p{IsSupplementaryPrivateUseArea-A}+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0289">
+	{
+		regex: "~p{IsSupplementaryPrivateUseArea-B}+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0290">
+	{
+		regex: "~p{IsCJKCompatibilityIdeographs}+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0291">
+	{
+		regex: "~p{IsAlphabeticPresentationForms}+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0292">
+	{
+		regex: "~p{IsArabicPresentationForms-A}+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0293">
+	{
+		regex: "~p{IsCombiningHalfMarks}+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0294">
+	{
+		regex: "~p{IsCJKCompatibilityForms}+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0295">
+	{
+		regex: "~p{IsSmallFormVariants}+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0296">
+	{
+		regex: "~p{IsArabicPresentationForms-B}+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0297">
+	{
+		regex: "~p{IsHalfwidthandFullwidthForms}+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0298">
+	{
+		regex: "~p{IsSpecials}+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0299">
+	{
+		regex: "~p{IsBasicLatin}?",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0300">
+	{
+		regex: "~p{IsLatin-1Supplement}?",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0301">
+	{
+		regex: "~p{IsLatinExtended-A}?",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0302">
+	{
+		regex: "~p{IsLatinExtended-B}?",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0303">
+	{
+		regex: "~p{IsIPAExtensions}?",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0304">
+	{
+		regex: "~p{IsSpacingModifierLetters}?",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0305">
+	{
+		regex: "~p{IsCyrillic}?",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0306">
+	{
+		regex: "~p{IsArmenian}?",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0307">
+	{
+		regex: "~p{IsHebrew}?",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0308">
+	{
+		regex: "~p{IsArabic}?",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0309">
+	{
+		regex: "~p{IsSyriac}?",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0310">
+	{
+		regex: "~p{IsThaana}?",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0311">
+	{
+		regex: "~p{IsDevanagari}?",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0312">
+	{
+		regex: "~p{IsBengali}?",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0313">
+	{
+		regex: "~p{IsGurmukhi}?",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0314">
+	{
+		regex: "~p{IsGujarati}?",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0315">
+	{
+		regex: "~p{IsOriya}?",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0316">
+	{
+		regex: "~p{IsTamil}?",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0317">
+	{
+		regex: "~p{IsTelugu}?",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0318">
+	{
+		regex: "~p{IsKannada}?",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0319">
+	{
+		regex: "~p{IsMalayalam}?",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0320">
+	{
+		regex: "~p{IsSinhala}?",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0321">
+	{
+		regex: "~p{IsThai}?",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0322">
+	{
+		regex: "~p{IsLao}?",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0323">
+	{
+		regex: "~p{IsTibetan}?",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0324">
+	{
+		regex: "~p{IsMyanmar}?",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0325">
+	{
+		regex: "~p{IsGeorgian}?",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0326">
+	{
+		regex: "~p{IsHangulJamo}?",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0327">
+	{
+		regex: "~p{IsEthiopic}?",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0328">
+	{
+		regex: "~p{IsCherokee}?",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0329">
+	{
+		regex: "~p{IsUnifiedCanadianAboriginalSyllabics}?",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0330">
+	{
+		regex: "~p{IsOgham}?",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0331">
+	{
+		regex: "~p{IsRunic}?",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0332">
+	{
+		regex: "~p{IsKhmer}?",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0333">
+	{
+		regex: "~p{IsMongolian}?",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0334">
+	{
+		regex: "~p{IsLatinExtendedAdditional}?",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0335">
+	{
+		regex: "~p{IsGreekExtended}?",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0336">
+	{
+		regex: "~p{IsGeneralPunctuation}?",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0337">
+	{
+		regex: "~p{IsSuperscriptsandSubscripts}?",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0338">
+	{
+		regex: "~p{IsCurrencySymbols}?",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0339">
+	{
+		regex: "~p{IsCombiningDiacriticalMarksforSymbols}?",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0340">
+	{
+		regex: "~p{IsLetterlikeSymbols}?",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0341">
+	{
+		regex: "~p{IsNumberForms}?",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0342">
+	{
+		regex: "~p{IsArrows}?",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0343">
+	{
+		regex: "~p{IsMathematicalOperators}?",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0344">
+	{
+		regex: "~p{IsMiscellaneousTechnical}?",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0345">
+	{
+		regex: "~p{IsControlPictures}?",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0346">
+	{
+		regex: "~p{IsOpticalCharacterRecognition}?",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0347">
+	{
+		regex: "~p{IsEnclosedAlphanumerics}?",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0348">
+	{
+		regex: "~p{IsBoxDrawing}?",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0349">
+	{
+		regex: "~p{IsBlockElements}?",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0350">
+	{
+		regex: "~p{IsGeometricShapes}?",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0351">
+	{
+		regex: "~p{IsMiscellaneousSymbols}?",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0352">
+	{
+		regex: "~p{IsDingbats}?",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0353">
+	{
+		regex: "~p{IsBraillePatterns}?",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0354">
+	{
+		regex: "~p{IsCJKRadicalsSupplement}?",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0355">
+	{
+		regex: "~p{IsKangxiRadicals}?",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0356">
+	{
+		regex: "~p{IsIdeographicDescriptionCharacters}?",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0357">
+	{
+		regex: "~p{IsCJKSymbolsandPunctuation}?",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0358">
+	{
+		regex: "~p{IsHiragana}?",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0359">
+	{
+		regex: "~p{IsKatakana}?",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0360">
+	{
+		regex: "~p{IsBopomofo}?",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0361">
+	{
+		regex: "~p{IsHangulCompatibilityJamo}?",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0362">
+	{
+		regex: "~p{IsKanbun}?",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0363">
+	{
+		regex: "~p{IsBopomofoExtended}?",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0364">
+	{
+		regex: "~p{IsEnclosedCJKLettersandMonths}?",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0365">
+	{
+		regex: "~p{IsCJKCompatibility}?",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0366">
+	{
+		regex: "~p{IsCJKUnifiedIdeographsExtensionA}?",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0367">
+	{
+		regex: "~p{IsCJKUnifiedIdeographs}?",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0368">
+	{
+		regex: "~p{IsYiSyllables}?",
+		valid: false,
+	},
+	//    <!--<test-case name="regex-syntax-0369">
+	{
+		regex: "~p{IsYiRadicals}?",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0370">
+	{
+		regex: "~p{IsLowSurrogates}?",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0370a">
+	{
+		regex: "~p{IsPrivateUseArea}?",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0371">
+	{
+		regex: "~p{IsSupplementaryPrivateUseArea-B}?",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0372">
+	{
+		regex: "~p{IsCJKCompatibilityIdeographs}?",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0373">
+	{
+		regex: "~p{IsAlphabeticPresentationForms}?",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0374">
+	{
+		regex: "~p{IsArabicPresentationForms-A}?",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0375">
+	{
+		regex: "~p{IsCombiningHalfMarks}?",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0376">
+	{
+		regex: "~p{IsCJKCompatibilityForms}?",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0377">
+	{
+		regex: "~p{IsSmallFormVariants}?",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0378">
+	{
+		regex: "~p{IsSpecials}?",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0379">
+	{
+		regex: "~p{IsHalfwidthandFullwidthForms}?",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0380">
+	{
+		regex: "~p{IsOldItalic}?",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0381">
+	{
+		regex: "~p{IsGothic}?",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0382">
+	{
+		regex: "~p{IsDeseret}?",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0383">
+	{
+		regex: "~p{IsByzantineMusicalSymbols}?",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0384">
+	{
+		regex: "~p{IsMusicalSymbols}?",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0385">
+	{
+		regex: "~p{IsMathematicalAlphanumericSymbols}?",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0386">
+	{
+		regex: "~p{IsCJKUnifiedIdeographsExtensionB}?",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0387">
+	{
+		regex: "~p{IsCJKCompatibilityIdeographsSupplement}?",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0388">
+	{
+		regex: "~p{IsTags}?",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0389">
+	{
+		regex: "~p{IsBasicLatin}",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0390">
+	{
+		regex: "~p{IsLatin-1Supplement}",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0391">
+	{
+		regex: "~p{IsLatinExtended-A}",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0392">
+	{
+		regex: "~p{IsLatinExtended-B}",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0393">
+	{
+		regex: "~p{IsIPAExtensions}",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0394">
+	{
+		regex: "~p{IsSpacingModifierLetters}",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0395">
+	{
+		regex: "~p{IsGreekandCoptic}",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0396">
+	{
+		regex: "~p{IsCyrillic}",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0397">
+	{
+		regex: "~p{IsArmenian}",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0398">
+	{
+		regex: "~p{IsHebrew}",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0399">
+	{
+		regex: "~p{IsArabic}",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0400">
+	{
+		regex: "~p{IsSyriac}",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0401">
+	{
+		regex: "~p{IsThaana}",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0402">
+	{
+		regex: "~p{IsDevanagari}",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0403">
+	{
+		regex: "~p{IsBengali}",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0404">
+	{
+		regex: "~p{IsGurmukhi}",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0405">
+	{
+		regex: "~p{IsGujarati}",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0406">
+	{
+		regex: "~p{IsOriya}",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0407">
+	{
+		regex: "~p{IsTamil}",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0408">
+	{
+		regex: "~p{IsTelugu}",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0409">
+	{
+		regex: "~p{IsKannada}",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0410">
+	{
+		regex: "~p{IsMalayalam}",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0411">
+	{
+		regex: "~p{IsSinhala}",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0412">
+	{
+		regex: "~p{IsThai}",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0413">
+	{
+		regex: "~p{IsLao}",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0414">
+	{
+		regex: "~p{IsTibetan}",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0415">
+	{
+		regex: "~p{IsMyanmar}",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0416">
+	{
+		regex: "~p{IsGeorgian}",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0417">
+	{
+		regex: "~p{IsHangulJamo}",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0418">
+	{
+		regex: "~p{IsEthiopic}",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0419">
+	{
+		regex: "~p{IsCherokee}",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0420">
+	{
+		regex: "~p{IsUnifiedCanadianAboriginalSyllabics}",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0421">
+	{
+		regex: "~p{IsOgham}",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0422">
+	{
+		regex: "~p{IsRunic}",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0423">
+	{
+		regex: "~p{IsKhmer}",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0424">
+	{
+		regex: "~p{IsMongolian}",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0425">
+	{
+		regex: "~p{IsLatinExtendedAdditional}",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0426">
+	{
+		regex: "~p{IsGreekExtended}",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0427">
+	{
+		regex: "~p{IsGeneralPunctuation}",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0428">
+	{
+		regex: "~p{IsSuperscriptsandSubscripts}",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0429">
+	{
+		regex: "~p{IsCurrencySymbols}",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0430">
+	{
+		regex: "~p{IsCombiningDiacriticalMarksforSymbols}",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0431">
+	{
+		regex: "~p{IsLetterlikeSymbols}",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0432">
+	{
+		regex: "~p{IsNumberForms}",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0433">
+	{
+		regex: "~p{IsArrows}",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0434">
+	{
+		regex: "~p{IsMathematicalOperators}",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0435">
+	{
+		regex: "~p{IsMiscellaneousTechnical}",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0436">
+	{
+		regex: "~p{IsControlPictures}",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0437">
+	{
+		regex: "~p{IsOpticalCharacterRecognition}",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0438">
+	{
+		regex: "~p{IsEnclosedAlphanumerics}",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0439">
+	{
+		regex: "~p{IsBoxDrawing}",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0440">
+	{
+		regex: "~p{IsBlockElements}",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0441">
+	{
+		regex: "~p{IsGeometricShapes}",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0442">
+	{
+		regex: "~p{IsMiscellaneousSymbols}",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0443">
+	{
+		regex: "~p{IsDingbats}",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0444">
+	{
+		regex: "~p{IsBraillePatterns}",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0445">
+	{
+		regex: "~p{IsCJKRadicalsSupplement}",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0446">
+	{
+		regex: "~p{IsKangxiRadicals}",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0447">
+	{
+		regex: "~p{IsIdeographicDescriptionCharacters}",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0448">
+	{
+		regex: "~p{IsCJKSymbolsandPunctuation}",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0449">
+	{
+		regex: "~p{IsHiragana}",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0450">
+	{
+		regex: "~p{IsKatakana}",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0451">
+	{
+		regex: "~p{IsBopomofo}",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0452">
+	{
+		regex: "~p{IsHangulCompatibilityJamo}",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0453">
+	{
+		regex: "~p{IsKanbun}",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0454">
+	{
+		regex: "~p{IsBopomofoExtended}",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0455">
+	{
+		regex: "~p{IsEnclosedCJKLettersandMonths}",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0456">
+	{
+		regex: "~p{IsCJKCompatibility}",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0457">
+	{
+		regex: "~p{IsCJKUnifiedIdeographsExtensionA}",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0458">
+	{
+		regex: "~p{IsCJKUnifiedIdeographs}",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0459">
+	{
+		regex: "~p{IsYiSyllables}",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0460">
+	{
+		regex: "~p{IsYiRadicals}",
+		valid: false,
+	},
+	//    <!--<test-case name="regex-syntax-0461">
+	{
+		regex: "~p{IsHangulSyllables}",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0462">
+	{
+		regex: "~p{IsHighSurrogates}",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0463">
+	{
+		regex: "~p{IsCJKCompatibilityIdeographs}",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0464">
+	{
+		regex: "~p{IsAlphabeticPresentationForms}",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0465">
+	{
+		regex: "~p{IsArabicPresentationForms-A}",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0466">
+	{
+		regex: "~p{IsCombiningHalfMarks}",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0467">
+	{
+		regex: "~p{IsCJKCompatibilityForms}",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0468">
+	{
+		regex: "~p{IsSmallFormVariants}",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0469">
+	{
+		regex: "~p{IsArabicPresentationForms-B}",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0470">
+	{
+		regex: "~p{IsSpecials}",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0471">
+	{
+		regex: "~p{IsHalfwidthandFullwidthForms}",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0472">
+	{
+		regex: "~p{IsOldItalic}",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0473">
+	{
+		regex: "~p{IsGothic}",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0474">
+	{
+		regex: "~p{IsDeseret}",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0475">
+	{
+		regex: "~p{IsByzantineMusicalSymbols}",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0476">
+	{
+		regex: "~p{IsMusicalSymbols}",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0477">
+	{
+		regex: "~p{IsMathematicalAlphanumericSymbols}",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0478">
+	{
+		regex: "~p{IsCJKUnifiedIdeographsExtensionB}",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0479">
+	{
+		regex: "~p{IsCJKCompatibilityIdeographsSupplement}",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0480">
+	{
+		regex: "~p{IsTags}",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0481">
+	{
+		regex: "~p{IsSupplementaryPrivateUseArea-A}",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0482">
+	{
+		regex:     ".",
+		matches:   []string{"a", " "},
+		nomatches: []string{"aa", ""},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0483">
+	{
+		regex: "~s",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0484">
+	{
+		regex: "~s*~c~s?~c~s+~c~s*",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0485">
+	{
+		regex: "a~s{0,3}a",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0486">
+	{
+		regex: "a~sb",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0487">
+	{
+		regex: "~S",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0488">
+	{
+		regex: "~S+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0489">
+	{
+		regex: "~S*",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0490">
+	{
+		regex: "~S?~s?~S?~s+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0491">
+	{
+		regex: "~i",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0492">
+	{
+		regex: "~i*",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0493">
+	{
+		regex: "~i+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0494">
+	{
+		regex: "~c~i*a",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0495">
+	{
+		regex: "[~s~i]*",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0496">
+	{
+		regex: "~I",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0497">
+	{
+		regex: "~I*",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0498">
+	{
+		regex: "a~I+~c",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0499">
+	{
+		regex: "~c",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0500">
+	{
+		regex: "~c?~?~d~s~c+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0501">
+	{
+		regex: "~c?~c+~c*",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0502">
+	{
+		regex: "~C",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0503">
+	{
+		regex: "~c~C?~c~C+~c~C*",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0504">
+	{
+		regex: "~d",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0505">
+	{
+		regex: "~D",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0506">
+	{
+		regex: "~w",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0507">
+	{
+		regex: "~W",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0508">
+	{
+		regex:     "true",
+		matches:   []string{"true"},
+		nomatches: []string{"false"},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0509">
+	{
+		regex:     "false",
+		matches:   []string{"false"},
+		nomatches: []string{"true"},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0510">
+	{
+		regex:     "(true|false)",
+		matches:   []string{"egex\" as=\""},
+		nomatches: []string{""},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0511">
+	{
+		regex:     "(1|true)",
+		matches:   []string{"1"},
+		nomatches: []string{"0"},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0512">
+	{
+		regex:     "(1|true|false|0|0)",
+		matches:   []string{"0"},
+		nomatches: []string{""},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0513">
+	{
+		regex:     "([0-1]{4}|(0|1){8})",
+		matches:   []string{"1111", "11001010"},
+		nomatches: []string{""},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0514">
+	{
+		regex:     "AF01D1",
+		matches:   []string{"AF01D1"},
+		nomatches: []string{""},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0515">
+	{
+		regex: "~d*~.~d+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0516">
+	{
+		regex: "http://~c*",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0517">
+	{
+		regex: "[~i~c]+:[~i~c]+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0518">
+	{
+		regex:     "P~p{Nd}{4}Y~p{Nd}{2}M",
+		matches:   []string{"P1111Y12M"},
+		nomatches: []string{"P111Y12M", "P1111Y1M", "P11111Y12M", "P1111Y", "P12M", "P11111Y00M", "P11111Y13M"},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0519">
+	{
+		regex: "~p{Nd}{4}-~d~d-~d~dT~d~d:~d~d:~d~d",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0520">
+	{
+		regex: "~p{Nd}{2}:~d~d:~d~d(~-~d~d:~d~d)?",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0521">
+	{
+		regex:     "~p{Nd}{4}-~p{Nd}{2}-~p{Nd}{2}",
+		matches:   []string{"1999-12-12"},
+		nomatches: []string{""},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0522">
+	{
+		regex: "~p{Nd}{4}-~[{Nd}{2}",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0523">
+	{
+		regex:     "~p{Nd}{4}",
+		matches:   []string{"1999"},
+		nomatches: []string{""},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0524">
+	{
+		regex:     "~p{Nd}{2}",
+		matches:   []string{""},
+		nomatches: []string{"1999"},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0525">
+	{
+		regex:     "--0[123]~-(12|14)",
+		matches:   []string{"--03-14"},
+		nomatches: []string{""},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0526">
+	{
+		regex:     "---([123]0)|([12]?[1-9])|(31)",
+		matches:   []string{"---30"},
+		nomatches: []string{""},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0527">
+	{
+		regex:     "--((0[1-9])|(1(1|2)))--",
+		matches:   []string{"--12--"},
+		nomatches: []string{""},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0528">
+	{
+		regex: "~c+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0529">
+	{
+		regex: "~c{2,4}",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0530">
+	{
+		regex: "[~i~c]*",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0531">
+	{
+		regex: "~c[~c~d]*",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0532">
+	{
+		regex:     "~p{Nd}+",
+		matches:   []string{"10000101", "10000201"},
+		nomatches: []string{""},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0533">
+	{
+		regex: "~-~d~d",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0534">
+	{
+		regex: "~-?~d",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0535">
+	{
+		regex: "~d+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0536">
+	{
+		regex:     "~-?[0-3]{3}",
+		matches:   []string{"-300"},
+		nomatches: []string{""},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0537">
+	{
+		regex:     "((~-|~+)?[1-127])|(~-?128)",
+		matches:   []string{"-128"},
+		nomatches: []string{""},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0538">
+	{
+		regex: "~p{Nd}~d+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0539">
+	{
+		regex: "~d+~d+~d+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0540">
+	{
+		regex: "~d+~d+~p{Nd}~d+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0541">
+	{
+		regex: "~+?~d",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0542">
+	{
+		regex: "++",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0543">
+	{
+		regex:     "[0-9]*",
+		matches:   []string{"9", "0"},
+		nomatches: []string{""},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0544">
+	{
+		regex:     "~-[0-9]*",
+		matches:   []string{"-11111", "-9"},
+		nomatches: []string{""},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0545">
+	{
+		regex:     "[13]",
+		matches:   []string{"1", "3"},
+		nomatches: []string{"2"},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0546">
+	{
+		regex:     "[123]+|[abc]+",
+		matches:   []string{"112233123", "abcaabbccabc"},
+		nomatches: []string{"1a", "a1"},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0547">
+	{
+		regex:     "([abc]+)|([123]+)",
+		matches:   []string{"112233123", "abcaabbccabc", "abab"},
+		nomatches: []string{"1a", "1a", "x"},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0548">
+	{
+		regex:     "[abxyz]+",
+		matches:   []string{"abab"},
+		nomatches: []string{""},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0549">
+	{
+		regex: "(~p{Lu}~w*)~s(~p{Lu}~w*)",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0550">
+	{
+		regex: "(~p{Lu}~p{Ll}*)~s(~p{Lu}~p{Ll}*)",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0551">
+	{
+		regex: "(~P{Ll}~p{Ll}*)~s(~P{Ll}~p{Ll}*)",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0552">
+	{
+		regex: "(~P{Lu}+~p{Lu})~s(~P{Lu}+~p{Lu})",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0553">
+	{
+		regex: "(~p{Lt}~w*)~s(~p{Lt}*~w*)",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0554">
+	{
+		regex: "(~P{Lt}~w*)~s(~P{Lt}*~w*)",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0555">
+	{
+		regex:     "[@-D]+",
+		matches:   []string{""},
+		nomatches: []string{"eE?@ABCDabcdeE"},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0556">
+	{
+		regex:     "[>-D]+",
+		matches:   []string{""},
+		nomatches: []string{"eE=>?@ABCDabcdeE"},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0557">
+	{
+		regex: "[~u0554-~u0557]+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0558">
+	{
+		regex:     "[X-~]]+",
+		matches:   []string{""},
+		nomatches: []string{"wWXYZxyz[~]^"},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0559">
+	{
+		regex: "[X-~u0533]+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0560">
+	{
+		regex:     "[X-a]+",
+		matches:   []string{""},
+		nomatches: []string{"wWAXYZaxyz"},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0561">
+	{
+		regex:     "[X-c]+",
+		matches:   []string{""},
+		nomatches: []string{"wWABCXYZabcxyz"},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0562">
+	{
+		regex: "[X-~u00C0]+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0563">
+	{
+		regex: "[~u0100~u0102~u0104]+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0564">
+	{
+		regex: "[B-D~u0130]+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0565">
+	{
+		regex: "[~u013B~u013D~u013F]+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0566">
+	{
+		regex:     "(Foo) (Bar)",
+		matches:   []string{"Foo Bar", "Foo Bar"},
+		nomatches: []string{""},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0567">
+	{
+		regex: "~p{klsak",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0568">
+	{
+		regex: "{5",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0569">
+	{
+		regex: "{5,",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0570">
+	{
+		regex: "{5,6",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0571">
+	{
+		regex: "(?r:foo)",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0572">
+	{
+		regex: "(?c:foo)",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0573">
+	{
+		regex: "(?n:(foo)(~s+)(bar))",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0574">
+	{
+		regex: "(?e:foo)",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0575">
+	{
+		regex: "(?+i:foo)",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0576">
+	{
+		regex: "foo([~d]*)bar",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0577">
+	{
+		regex: "([~D]*)bar",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0578">
+	{
+		regex: "foo([~s]*)bar",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0579">
+	{
+		regex: "foo([~S]*)",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0580">
+	{
+		regex: "foo([~w]*)",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0581">
+	{
+		regex: "foo([~W]*)bar",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0582">
+	{
+		regex: "([~p{Lu}]~w*)~s([~p{Lu}]~w*)",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0583">
+	{
+		regex: "([~P{Ll}][~p{Ll}]*)~s([~P{Ll}][~p{Ll}]*)",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0584">
+	{
+		regex: "foo([a-~d]*)bar",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0585">
+	{
+		regex: "([5-~D]*)bar",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0586">
+	{
+		regex: "foo([6-~s]*)bar",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0587">
+	{
+		regex: "foo([c-~S]*)",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0588">
+	{
+		regex: "foo([7-~w]*)",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0589">
+	{
+		regex: "foo([a-~W]*)bar",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0590">
+	{
+		regex: "([f-~p{Lu}]~w*)~s([~p{Lu}]~w*)",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0591">
+	{
+		regex: "([1-~P{Ll}][~p{Ll}]*)~s([~P{Ll}][~p{Ll}]*)",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0592">
+	{
+		regex: "[~p]",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0593">
+	{
+		regex: "[~P]",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0594">
+	{
+		regex: "([~pfoo])",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0595">
+	{
+		regex: "([~Pfoo])",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0596">
+	{
+		regex: "(~p{",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0597">
+	{
+		regex: "(~p{Ll",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0598">
+	{
+		regex: "(foo)([~x41]*)(bar)",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0599">
+	{
+		regex: "(foo)([~u0041]*)(bar)",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0600">
+	{
+		regex:     "(foo)([~r]*)(bar)",
+		matches:   []string{""},
+		nomatches: []string{"foo   bar"},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0601">
+	{
+		regex: "(foo)([~o]*)(bar)",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0602">
+	{
+		regex: "(foo)~d*bar",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0603">
+	{
+		regex: "~D*(bar)",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0604">
+	{
+		regex: "(foo)~s*(bar)",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0605">
+	{
+		regex: "(foo)~S*",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0606">
+	{
+		regex: "(foo)~w*",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0607">
+	{
+		regex: "(foo)~W*(bar)",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0608">
+	{
+		regex: "~p{Lu}(~w*)~s~p{Lu}(~w*)",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0609">
+	{
+		regex: "~P{Ll}~p{Ll}*~s~P{Ll}~p{Ll}*",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0610">
+	{
+		regex: "foo(?(?#COMMENT)foo)",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0611">
+	{
+		regex: "foo(?(?afdfoo)bar)",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0612">
+	{
+		regex: "(foo) #foo        ~s+ #followed by 1 or more whitespace        (bar)  #followed by bar        ",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0613">
+	{
+		regex: "(foo) #foo        ~s+ #followed by 1 or more whitespace        (bar)  #followed by bar",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0614">
+	{
+		regex: "(foo) (?#foo) ~s+ (?#followed by 1 or more whitespace) (bar)  (?#followed by bar)",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0615">
+	{
+		regex: "(foo) (?#foo) ~s+ (?#followed by 1 or more whitespace",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0616">
+	{
+		regex: "(foo)(~077)",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0617">
+	{
+		regex: "(foo)(~77)",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0618">
+	{
+		regex: "(foo)(~176)",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0619">
+	{
+		regex: "(foo)(~300)",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0620">
+	{
+		regex: "(foo)(~477)",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0621">
+	{
+		regex: "(foo)(~777)",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0622">
+	{
+		regex: "(foo)(~7770)",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0623">
+	{
+		regex: "(foo)(~7)",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0624">
+	{
+		regex: "(foo)(~40)",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0625">
+	{
+		regex: "(foo)(~040)",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0626">
+	{
+		regex: "(foo)(~377)",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0627">
+	{
+		regex: "(foo)(~400)",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0628">
+	{
+		regex: "(foo)(~x2a*)(bar)",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0629">
+	{
+		regex: "(foo)(~x2b*)(bar)",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0630">
+	{
+		regex: "(foo)(~x2c*)(bar)",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0631">
+	{
+		regex: "(foo)(~x2d*)(bar)",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0632">
+	{
+		regex: "(foo)(~x2e*)(bar)",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0633">
+	{
+		regex: "(foo)(~x2f*)(bar)",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0634">
+	{
+		regex: "(foo)(~x2A*)(bar)",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0635">
+	{
+		regex: "(foo)(~x2B*)(bar)",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0636">
+	{
+		regex: "(foo)(~x2C*)(bar)",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0637">
+	{
+		regex: "(foo)(~x2D*)(bar)",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0638">
+	{
+		regex: "(foo)(~x2E*)(bar)",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0639">
+	{
+		regex: "(foo)(~x2F*)(bar)",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0640">
+	{
+		regex: "(foo)(~c*)(bar)",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0641">
+	{
+		regex: "(foo)~c",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0642">
+	{
+		regex: "(foo)(~c *)(bar)",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0643">
+	{
+		regex: "(foo)(~c?*)(bar)",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0644">
+	{
+		regex: "(foo)(~c`*)(bar)",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0645">
+	{
+		regex: "(foo)(~c~|*)(bar)",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0646">
+	{
+		regex: "(foo)(~c~[*)(bar)",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0647">
+	{
+		regex: "~A(foo)~s+(bar)",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0648">
+	{
+		regex: "(foo)~s+(bar)~Z",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0649">
+	{
+		regex: "(foo)~s+(bar)~z",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0650">
+	{
+		regex: "~b@foo",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0651">
+	{
+		regex: "~b,foo",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0652">
+	{
+		regex: "~b~[foo",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0653">
+	{
+		regex: "~B@foo",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0654">
+	{
+		regex: "~B,foo",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0655">
+	{
+		regex: "~B~[foo",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0656">
+	{
+		regex: "(~w+)~s+(~w+)",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0657">
+	{
+		regex: "(foo~w+)~s+(bar~w+)",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0658">
+	{
+		regex:     "([^{}]|~n)+",
+		matches:   []string{""},
+		nomatches: []string{"{{{{Hello  World  }END"},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0659">
+	{
+		regex:     "(([0-9])|([a-z])|([A-Z]))*",
+		matches:   []string{""},
+		nomatches: []string{"{hello 1234567890 world}", "{HELLO 1234567890 world}", "{1234567890 hello  world}"},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0660">
+	{
+		regex:     "(([0-9])|([a-z])|([A-Z]))+",
+		matches:   []string{""},
+		nomatches: []string{"{hello 1234567890 world}", "{HELLO 1234567890 world}", "{1234567890 hello world}"},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0661">
+	{
+		regex:     "(([a-d]*)|([a-z]*))",
+		matches:   []string{"aaabbbcccdddeeefff"},
+		nomatches: []string{""},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0662">
+	{
+		regex:     "(([d-f]*)|([c-e]*))",
+		matches:   []string{"dddeeeccceee"},
+		nomatches: []string{""},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0663">
+	{
+		regex:     "(([c-e]*)|([d-f]*))",
+		matches:   []string{"dddeeeccceee"},
+		nomatches: []string{""},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0664">
+	{
+		regex:     "(([a-d]*)|(.*))",
+		matches:   []string{"aaabbbcccdddeeefff"},
+		nomatches: []string{""},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0665">
+	{
+		regex:     "(([d-f]*)|(.*))",
+		matches:   []string{"dddeeeccceee"},
+		nomatches: []string{""},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0666">
+	{
+		regex:     "(([c-e]*)|(.*))",
+		matches:   []string{"dddeeeccceee"},
+		nomatches: []string{""},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0667">
+	{
+		regex:     "CH",
+		matches:   []string{""},
+		nomatches: []string{"Ch", "Ch"},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0668">
+	{
+		regex:     "cH",
+		matches:   []string{""},
+		nomatches: []string{"/>\n  "},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0669">
+	{
+		regex:     "AA",
+		matches:   []string{""},
+		nomatches: []string{"Aa", "Aa"},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0670">
+	{
+		regex:     "aA",
+		matches:   []string{""},
+		nomatches: []string{"Aa", "Aa"},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0671">
+	{
+		regex:     "ı",
+		matches:   []string{""},
+		nomatches: []string{"I", "I", "I", "i", "I", "i"},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0672">
+	{
+		regex:     "İ",
+		matches:   []string{""},
+		nomatches: []string{"i", "i", "I", "i", "I", "i"},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0673">
+	{
+		regex: "([0-9]+?)([~w]+?)",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0674">
+	{
+		regex: "([0-9]+?)([a-z]+?)",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0675">
+	{
+		regex: "^[abcd]{0,16}*$",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0676">
+	{
+		regex: "^[abcd]{1,}*$",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0677">
+	{
+		regex: "^[abcd]{1}*$",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0678">
+	{
+		regex: "^[abcd]{0,16}?*$",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0679">
+	{
+		regex: "^[abcd]{1,}?*$",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0680">
+	{
+		regex: "^[abcd]{1}?*$",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0681">
+	{
+		regex: "^[abcd]*+$",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0682">
+	{
+		regex: "^[abcd]+*$",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0683">
+	{
+		regex: "^[abcd]?*$",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0684">
+	{
+		regex: "^[abcd]*?+$",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0685">
+	{
+		regex: "^[abcd]+?*$",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0686">
+	{
+		regex: "^[abcd]??*$",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0687">
+	{
+		regex: "^[abcd]*{0,5}$",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0688">
+	{
+		regex: "^[abcd]+{0,5}$",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0689">
+	{
+		regex: "^[abcd]?{0,5}$",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0690">
+	{
+		regex: "http://([a-zA-z0-9~-]*~.?)*?(:[0-9]*)??/",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0691">
+	{
+		regex: "http://([a-zA-Z0-9~-]*~.?)*?/",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0692">
+	{
+		regex: "([a-z]*?)([~w])",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0693">
+	{
+		regex: "([a-z]*)([~w])",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0694">
+	{
+		regex: "[abcd-[d]]+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0695">
+	{
+		regex: "[~d-[357]]+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0696">
+	{
+		regex: "[~w-[b-y]]+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0697">
+	{
+		regex: "[~w-[~d]]+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0698">
+	{
+		regex: "[~w-[~p{Ll}]]+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0699">
+	{
+		regex: "[~d-[13579]]+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0700">
+	{
+		regex: "[~p{Ll}-[ae-z]]+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0701">
+	{
+		regex: "[~p{Nd}-[2468]]+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0702">
+	{
+		regex: "[~P{Lu}-[ae-z]]+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0703">
+	{
+		regex: "[abcd-[def]]+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0704">
+	{
+		regex: "[~d-[357a-z]]+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0705">
+	{
+		regex: "[~d-[de357fgA-Z]]+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0706">
+	{
+		regex: "[~d-[357~p{Ll}]]+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0707">
+	{
+		regex: "[~w-[b-y~s]]+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0708">
+	{
+		regex: "[~w-[~d~p{Po}]]+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0709">
+	{
+		regex: "[~w-[~p{Ll}~s]]+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0710">
+	{
+		regex: "[~d-[13579a-zA-Z]]+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0711">
+	{
+		regex: "[~d-[13579abcd]]+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0712">
+	{
+		regex: "[~d-[13579~s]]+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0713">
+	{
+		regex: "[~w-[b-y~p{Po}]]+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0714">
+	{
+		regex: "[~w-[b-y!.,]]+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0715">
+	{
+		regex: "[~p{Ll}-[ae-z0-9]]+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0716">
+	{
+		regex: "[~p{Nd}-[2468az]]+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0717">
+	{
+		regex: "[~P{Lu}-[ae-zA-Z]]+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0718">
+	{
+		regex: "[abc-[defg]]+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0719">
+	{
+		regex: "[~d-[abc]]+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0720">
+	{
+		regex: "[~d-[a-zA-Z]]+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0721">
+	{
+		regex: "[~d-[~p{Ll}]]+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0722">
+	{
+		regex: "[~w-[~p{Po}]]+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0723">
+	{
+		regex: "[~d-[~D]]+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0724">
+	{
+		regex: "[a-zA-Z0-9-[~s]]+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0725">
+	{
+		regex: "[~p{Ll}-[A-Z]]+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0726">
+	{
+		regex: "[~p{Nd}-[a-z]]+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0727">
+	{
+		regex: "[~P{Lu}-[~p{Lu}]]+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0728">
+	{
+		regex: "[~P{Lu}-[A-Z]]+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0729">
+	{
+		regex: "[~P{Nd}-[~p{Nd}]]+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0730">
+	{
+		regex: "[~P{Nd}-[2-8]]+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0731">
+	{
+		regex: "([ ]|[~w-[0-9]])+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0732">
+	{
+		regex: "([0-9-[02468]]|[0-9-[13579]])+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0733">
+	{
+		regex: "([^0-9-[a-zAE-Z]]|[~w-[a-zAF-Z]])+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0734">
+	{
+		regex: "([~p{Ll}-[aeiou]]|[^~w-[~s]])+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0735">
+	{
+		regex: "98[~d-[9]][~d-[8]][~d-[0]]",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0736">
+	{
+		regex: "m[~w-[^aeiou]][~w-[^aeiou]]t",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0737">
+	{
+		regex: "[abcdef-[^bce]]+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0738">
+	{
+		regex: "[^cde-[ag]]+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0739">
+	{
+		regex: "[~p{IsGreekandCoptic}-[~P{Lu}]]+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0740">
+	{
+		regex: "[a-zA-Z-[aeiouAEIOU]]+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0741">
+	{
+		regex: "[abcd~-d-[bc]]+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0742">
+	{
+		regex: "[^a-f-[~x00-~x60~u007B-~uFFFF]]+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0743">
+	{
+		regex: "[a-f-[]]+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0744">
+	{
+		regex: "[~[~]a-f-[[]]+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0745">
+	{
+		regex: "[~[~]a-f-[]]]+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0746">
+	{
+		regex: "[ab~-~[cd-[-[]]]]",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0747">
+	{
+		regex: "[ab~-~[cd-[[]]]]",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0748">
+	{
+		regex: "[a-[a-f]]",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0749">
+	{
+		regex: "[a-[c-e]]+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0750">
+	{
+		regex: "[a-d~--[bc]]+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0751">
+	{
+		regex: "[[abcd]-[bc]]+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0752">
+	{
+		regex: "[-[e-g]+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0753">
+	{
+		regex:     "[-e-g]+",
+		matches:   []string{""},
+		nomatches: []string{"ddd---eeefffggghhh", "ddd---eeefffggghhh"},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0754">
+	{
+		regex:     "[a-e - m-p]+",
+		matches:   []string{""},
+		nomatches: []string{"---a b c d e m n o p---"},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0755">
+	{
+		regex: "[^-[bc]]",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0756">
+	{
+		regex: "[A-[]+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0757">
+	{
+		regex: "[a~-[bc]+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0758">
+	{
+		regex: "[a~-[~-~-bc]+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0759">
+	{
+		regex:     "[a~-~[~-~[~-bc]+",
+		matches:   []string{""},
+		nomatches: []string{"```bbbaaa---[[[cccddd"},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0760">
+	{
+		regex: "[abc~--[b]]+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0761">
+	{
+		regex: "[abc~-z-[b]]+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0762">
+	{
+		regex: "[a-d~-[b]+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0763">
+	{
+		regex: "[abcd~-d~-[bc]+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0764">
+	{
+		regex: "[a - c - [ b ] ]+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0765">
+	{
+		regex: "[a - c - [ b ] +",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0766">
+	{
+		regex: "(?<first_name>~~S+)~~s(?<last_name>~~S+)",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0767">
+	{
+		regex: "(a+)(?:b*)(ccc)",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0768">
+	{
+		regex: "abc(?=XXX)~w+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0769">
+	{
+		regex: "abc(?!XXX)~w+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0770">
+	{
+		regex: "[^0-9]+(?>[0-9]+)3",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0771">
+	{
+		regex:     "^aa$",
+		matches:   []string{""},
+		nomatches: []string{"aA"},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0772">
+	{
+		regex:     "^Aa$",
+		matches:   []string{""},
+		nomatches: []string{"aA"},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0773">
+	{
+		regex: "~s+~d+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0774">
+	{
+		regex: "foo~d+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0775">
+	{
+		regex: "foo~s+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0776">
+	{
+		regex: "(hello)foo~s+bar(world)",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0777">
+	{
+		regex: "(hello)~s+(world)",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0778">
+	{
+		regex: "(foo)~s+(bar)",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0779">
+	{
+		regex: "(d)(o)(g)(~s)(c)(a)(t)(~s)(h)(a)(s)",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0780">
+	{
+		regex:     "^([a-z0-9]+)@([a-z]+)~.([a-z]+)$",
+		matches:   []string{""},
+		nomatches: []string{"bar@bar.foo.com"},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0781">
+	{
+		regex:     "^http://www.([a-zA-Z0-9]+)~.([a-z]+)$",
+		matches:   []string{""},
+		nomatches: []string{"http://www.foo.bar.com"},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0782">
+	{
+		regex:     "(.*)",
+		matches:   []string{"abc~nsfc"},
+		nomatches: []string{""},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0783">
+	{
+		regex:     "            ((.)+)      ",
+		matches:   []string{""},
+		nomatches: []string{"abc"},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0784">
+	{
+		regex:     " ([^/]+)       ",
+		matches:   []string{" abc       "},
+		nomatches: []string{""},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0785">
+	{
+		regex: ".*~B(SUCCESS)~B.*",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0786">
+	{
+		regex: "~060(~061)?~061",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0787">
+	{
+		regex: "(~x30~x31~x32)",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0788">
+	{
+		regex: "(~u0034)",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0789">
+	{
+		regex:     "(a+)(b*)(c?)",
+		matches:   []string{""},
+		nomatches: []string{"aaabbbccc"},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0790">
+	{
+		regex: "(d+?)(e*?)(f??)",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0791">
+	{
+		regex:     "(111|aaa)",
+		matches:   []string{"aaa"},
+		nomatches: []string{""},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0792">
+	{
+		regex: "(abbc)(?(1)111|222)",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0793">
+	{
+		regex: ".*~b(~w+)~b",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0794">
+	{
+		regex:     "a+~.?b*~.+c{2}",
+		matches:   []string{"ab.cc"},
+		nomatches: []string{""},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0795">
+	{
+		regex:     "(abra(cad)?)+",
+		matches:   []string{""},
+		nomatches: []string{"abracadabra1abracadabra2abracadabra3"},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0796">
+	{
+		regex:     "^(cat|chat)",
+		matches:   []string{""},
+		nomatches: []string{"scription>\n "},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0797">
+	{
+		regex:     "([0-9]+(~.[0-9]+){3})",
+		matches:   []string{"209.25.0.111"},
+		nomatches: []string{""},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0798">
+	{
+		regex:     "qqq(123)*",
+		matches:   []string{""},
+		nomatches: []string{"Startqqq123123End"},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0799">
+	{
+		regex: "(~s)?(-)",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0800">
+	{
+		regex:     "a(.)c(.)e",
+		matches:   []string{""},
+		nomatches: []string{"123abcde456aBCDe789"},
+		valid:     true,
+	},
+	//    <test-case name="regex-syntax-0801">
+	{
+		regex: "(~S+):~W(~d+)~s(~D+)",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0802">
+	{
+		regex: "a[b-a]",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0803">
+	{
+		regex: "a[]b",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0804">
+	{
+		regex: "a[",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0805">
+	{
+		regex: "a]",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0806">
+	{
+		regex: "a[]]b",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0807">
+	{
+		regex: "a[^]b]c",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0808">
+	{
+		regex: "~ba~b",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0809">
+	{
+		regex: "~by~b",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0810">
+	{
+		regex: "~Ba~B",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0811">
+	{
+		regex: "~By~b",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0812">
+	{
+		regex: "~by~B",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0813">
+	{
+		regex: "~By~B",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0814">
+	{
+		regex: "(*)b",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0815">
+	{
+		regex: "a~",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0816">
+	{
+		regex: "abc)",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0817">
+	{
+		regex: "(abc",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0818">
+	{
+		regex: "a**",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0819">
+	{
+		regex: "a.+?c",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0820">
+	{
+		regex: "))((",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0821">
+	{
+		regex: "~10((((((((((a))))))))))",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0822">
+	{
+		regex: "~1(abc)",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0823">
+	{
+		regex: "~1([a-c]*)",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0824">
+	{
+		regex: "~1",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0825">
+	{
+		regex: "~2",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0826">
+	{
+		regex: "(a)|~1",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0827">
+	{
+		regex: "(a)|~6",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0828">
+	{
+		regex: "(~2b*?([a-c]))*",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0829">
+	{
+		regex: "(~2b*?([a-c])){3}",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0830">
+	{
+		regex: "(x(a)~3(~2|b))+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0831">
+	{
+		regex: "((a)~3(~2|b)){2,}",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0832">
+	{
+		regex: "ab*?bc",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0833">
+	{
+		regex: "ab{0,}?bc",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0834">
+	{
+		regex: "ab+?bc",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0835">
+	{
+		regex: "ab{1,}?bc",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0836">
+	{
+		regex: "ab{1,3}?bc",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0837">
+	{
+		regex: "ab{3,4}?bc",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0838">
+	{
+		regex: "ab{4,5}?bc",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0839">
+	{
+		regex: "ab??bc",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0840">
+	{
+		regex: "ab{0,1}?bc",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0841">
+	{
+		regex: "ab??c",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0842">
+	{
+		regex: "ab{0,1}?c",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0843">
+	{
+		regex: "a.*?c",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0844">
+	{
+		regex: "a.{0,5}?c",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0845">
+	{
+		regex: "(a+|b){0,1}?",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0846">
+	{
+		regex: "(?:(?:(?:(?:(?:(?:(?:(?:(?:(a))))))))))",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0847">
+	{
+		regex: "(?:(?:(?:(?:(?:(?:(?:(?:(?:(a|b|c))))))))))",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0848">
+	{
+		regex: "(.)(?:b|c|d)a",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0849">
+	{
+		regex: "(.)(?:b|c|d)*a",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0850">
+	{
+		regex: "(.)(?:b|c|d)+?a",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0851">
+	{
+		regex: "(.)(?:b|c|d)+a",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0852">
+	{
+		regex: "(.)(?:b|c|d){2}a",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0853">
+	{
+		regex: "(.)(?:b|c|d){4,5}a",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0854">
+	{
+		regex: "(.)(?:b|c|d){4,5}?a",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0855">
+	{
+		regex: ":(?:",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0856">
+	{
+		regex: "(.)(?:b|c|d){6,7}a",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0857">
+	{
+		regex: "(.)(?:b|c|d){6,7}?a",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0858">
+	{
+		regex: "(.)(?:b|c|d){5,6}a",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0859">
+	{
+		regex: "(.)(?:b|c|d){5,6}?a",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0860">
+	{
+		regex: "(.)(?:b|c|d){5,7}a",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0861">
+	{
+		regex: "(.)(?:b|c|d){5,7}?a",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0862">
+	{
+		regex: "(.)(?:b|(c|e){1,2}?|d)+?a",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0863">
+	{
+		regex: "^(a~1?){4}$",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0864">
+	{
+		regex: "^(a(?(1)~1)){4}$",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0865">
+	{
+		regex: "(?:(f)(o)(o)|(b)(a)(r))*",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0866">
+	{
+		regex: "(?:..)*a",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0867">
+	{
+		regex: "(?:..)*?a",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0868">
+	{
+		regex: "(?:(?i)a)b",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0869">
+	{
+		regex: "((?i)a)b",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0870">
+	{
+		regex: "(?i:a)b",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0871">
+	{
+		regex: "((?i:a))b",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0872">
+	{
+		regex: "(?:(?-i)a)b",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0873">
+	{
+		regex: "((?-i)a)b",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0874">
+	{
+		regex: "(?-i:a)b",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0875">
+	{
+		regex: "((?-i:a))b",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0876">
+	{
+		regex: "((?-i:a.))b",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0877">
+	{
+		regex: "((?s-i:a.))b",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0878">
+	{
+		regex: "(?:c|d)(?:)(?:a(?:)(?:b)(?:b(?:))(?:b(?:)(?:b)))",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0879">
+	{
+		regex: "(?:c|d)(?:)(?:aaaaaaaa(?:)(?:bbbbbbbb)(?:bbbbbbbb(?:))(?:bbbbbbbb(?:)(?:bbbbbbbb)))",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0880">
+	{
+		regex: "~1~d(ab)",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0881">
+	{
+		regex: "x(~~)*(?:(?:F)?)?",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0882">
+	{
+		regex: "^a(?#xxx){3}c",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0883">
+	{
+		regex: "^a (?#xxx) (?#yyy) {3}c",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0884">
+	{
+		regex: "^(?:a?b?)*$",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0885">
+	{
+		regex: "((?s)^a(.))((?m)^b$)",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0886">
+	{
+		regex: "((?m)^b$)",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0887">
+	{
+		regex: "(?m)^b",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0888">
+	{
+		regex: "(?m)^(b)",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0889">
+	{
+		regex: "((?m)^b)",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0890">
+	{
+		regex: "~n((?m)^b)",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0891">
+	{
+		regex: "((?s).)c(?!.)",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0892">
+	{
+		regex: "((?s)b.)c(?!.)",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0893">
+	{
+		regex: "((c*)(?(1)a|b))",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0894">
+	{
+		regex: "((q*)(?(1)b|a))",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0895">
+	{
+		regex: "(?(1)a|b)(x)?",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0896">
+	{
+		regex: "(?(1)b|a)(x)?",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0897">
+	{
+		regex: "(?(1)b|a)()?",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0898">
+	{
+		regex: "(?(1)b|a)()",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0899">
+	{
+		regex: "(?(1)a|b)()?",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0900">
+	{
+		regex: "^(?(2)(~())blah(~))?$",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0901">
+	{
+		regex: "^(?(2)(~())blah(~)+)?$",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0902">
+	{
+		regex: "(?(1?)a|b)",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0903">
+	{
+		regex: "(?(1)a|b|c)",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0904">
+	{
+		regex: "(ba~2)(?=(a+?))",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0905">
+	{
+		regex: "ba~1(?=(a+?))$",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0906">
+	{
+		regex: "(?>a+)b",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0907">
+	{
+		regex: "([[:]+)",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0908">
+	{
+		regex: "([[=]+)",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0909">
+	{
+		regex: "([[.]+)",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0910">
+	{
+		regex: "[a[:xyz:",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0911">
+	{
+		regex: "[a[:xyz:]",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0912">
+	{
+		regex: "([a[:xyz:]b]+)",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0913">
+	{
+		regex: "((?>a+)b)",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0914">
+	{
+		regex: "(?>(a+))b",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0915">
+	{
+		regex: "((?>[^()]+)|~([^()]*~))+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0916">
+	{
+		regex: "a{37,17}",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0917">
+	{
+		regex: "a~Z",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0918">
+	{
+		regex: "b~Z",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0919">
+	{
+		regex: "b~z",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0920">
+	{
+		regex: "round~(((?>[^()]+))~)",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0921">
+	{
+		regex: "(a~1|(?(1)~1)){2}",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0922">
+	{
+		regex: "(a~1|(?(1)~1)){1,2}",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0923">
+	{
+		regex: "(a~1|(?(1)~1)){0,2}",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0924">
+	{
+		regex: "(a~1|(?(1)~1)){2,}",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0925">
+	{
+		regex: "(a~1|(?(1)~1)){1,2}?",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0926">
+	{
+		regex: "(a~1|(?(1)~1)){0,2}?",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0927">
+	{
+		regex: "(a~1|(?(1)~1)){2,}?",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0928">
+	{
+		regex: "~1a(~d*){0,2}",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0929">
+	{
+		regex: "~1a(~d*){2,}",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0930">
+	{
+		regex: "~1a(~d*){0,2}?",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0931">
+	{
+		regex: "~1a(~d*){2,}?",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0932">
+	{
+		regex: "z~1a(~d*){2,}?",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0933">
+	{
+		regex: "((((((((((a))))))))))~10",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0934">
+	{
+		regex: "(abc)~1",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0935">
+	{
+		regex: "([a-c]*)~1",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0936">
+	{
+		regex: "(([a-c])b*?~2)*",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0937">
+	{
+		regex: "(([a-c])b*?~2){3}",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0938">
+	{
+		regex: "((~3|b)~2(a)x)+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0939">
+	{
+		regex: "((~3|b)~2(a)){2,}",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0940">
+	{
+		regex: "a(?!b).",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0941">
+	{
+		regex: "a(?=d).",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0942">
+	{
+		regex: "a(?=c|d).",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0943">
+	{
+		regex: "a(?:b|c|d)(.)",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0944">
+	{
+		regex: "a(?:b|c|d)*(.)",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0945">
+	{
+		regex: "a(?:b|c|d)+?(.)",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0946">
+	{
+		regex: "a(?:b|c|d)+(.)",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0947">
+	{
+		regex: "a(?:b|c|d){2}(.)",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0948">
+	{
+		regex: "a(?:b|c|d){4,5}(.)",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0949">
+	{
+		regex: "a(?:b|c|d){4,5}?(.)",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0950">
+	{
+		regex: "a(?:b|c|d){6,7}(.)",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0951">
+	{
+		regex: "a(?:b|c|d){6,7}?(.)",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0952">
+	{
+		regex: "a(?:b|c|d){5,6}(.)",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0953">
+	{
+		regex: "a(?:b|c|d){5,6}?(.)",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0954">
+	{
+		regex: "a(?:b|c|d){5,7}(.)",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0955">
+	{
+		regex: "a(?:b|c|d){5,7}?(.)",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0956">
+	{
+		regex: "a(?:b|(c|e){1,2}?|d)+?(.)",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0957">
+	{
+		regex: "^(?:b|a(?=(.)))*~1",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0958">
+	{
+		regex: "(ab)~d~1",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0959">
+	{
+		regex: "((q*)(?(1)a|b))",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0960">
+	{
+		regex: "(x)?(?(1)a|b)",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0961">
+	{
+		regex: "(x)?(?(1)b|a)",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0962">
+	{
+		regex: "()?(?(1)b|a)",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0963">
+	{
+		regex: "()(?(1)b|a)",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0964">
+	{
+		regex: "()?(?(1)a|b)",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0965">
+	{
+		regex: "^(~()?blah(?(1)(~)))$",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0966">
+	{
+		regex: "^(~(+)?blah(?(1)(~)))$",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0967">
+	{
+		regex: "(?(?!a)a|b)",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0968">
+	{
+		regex: "(?(?!a)b|a)",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0969">
+	{
+		regex: "(?(?=a)b|a)",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0970">
+	{
+		regex: "(?(?=a)a|b)",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0971">
+	{
+		regex: "(?=(a+?))(~1ab)",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0972">
+	{
+		regex: "^(?=(a+?))~1ab",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0973">
+	{
+		regex: "(~d*){0,2}a~1",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0974">
+	{
+		regex: "(~d*){2,}a~1",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0975">
+	{
+		regex: "(~d*){0,2}?a~1",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0976">
+	{
+		regex: "(~d*){2,}?a~1",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0977">
+	{
+		regex: "(~d*){2,}?a~1z",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0978">
+	{
+		regex: "(?>~d+)3",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0979">
+	{
+		regex: "(~w(?=aa)aa)",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0980">
+	{
+		regex: "~p{IsCombiningDiacriticalMarks}+",
+		valid: false,
+	},
+	//    <!--<test-case name="regex-syntax-0981">
+	{
+		regex: "~p{IsCyrillic}+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0982">
+	{
+		regex: "~p{IsHighSurrogates}+",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0983">
+	{
+		regex: "^([0-9a-zA-Z]([-.~w]*[0-9a-zA-Z])*@(([0-9a-zA-Z])+([-~w]*[0-9a-zA-Z])*~.)+[a-zA-Z]{2,9})",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0984">
+	{
+		regex: "[~w~-~.]+@.*",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0985">
+	{
+		regex: "[~w]",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0986">
+	{
+		regex: "[~d]",
+		valid: false,
+	},
+	//    <test-case name="regex-syntax-0987">
+	{
+		regex: "[~i]",
+		valid: false,
+	},
+}

--- a/regexp_validity_test.go
+++ b/regexp_validity_test.go
@@ -1,0 +1,48 @@
+package quamina
+
+import (
+	"fmt"
+	"testing"
+)
+
+func oneRegexp(t *testing.T, re string, valid bool) {
+	t.Helper()
+	_, err := readRegexp(re)
+	if valid && err != nil {
+		t.Errorf("should be valid: /%s/, but <%s>", re, err.Error())
+	}
+	if (!valid) && err == nil {
+		t.Errorf("should NOT be valid: /%s/", re)
+	}
+	//fmt.Println("ERR: " + err.Error())
+}
+
+func TestDebugRegexp(t *testing.T) {
+	oneRegexp(t, "(~p{Ll}~p{Cc}~p{Nd})*", true)
+}
+
+func TestRegexpValidity(t *testing.T) {
+	problems := 0
+	tests := 0
+	for _, sample := range regexpSamples {
+		tests++
+		_, err := readRegexp(sample.regex)
+		if sample.valid {
+			if err != nil {
+				t.Errorf("should be valid: /%s/, but <%s> (after %d lines) ", sample.regex, err.Error(), tests)
+				problems++
+			}
+		} else {
+			if err == nil {
+				t.Errorf("should NOT be valid: /%s/ (after %d lines) ", sample.regex, tests)
+				problems++
+			}
+		}
+		if tests%100 == 0 {
+			fmt.Printf("Tests: %d\n", tests)
+		}
+		if problems == 10 {
+			return
+		}
+	}
+}

--- a/small_table_test.go
+++ b/small_table_test.go
@@ -62,3 +62,10 @@ func TestUnpack(t *testing.T) {
 		}
 	}
 }
+
+func TestDodgeBadUTF8(t *testing.T) {
+	st := makeSmallTable(nil, []byte{'a'}, []*faNext{{states: []*faState{{}}}})
+	so := &stepOut{}
+	st.step(0xFE, so)
+	st.dStep(0xFE)
+}

--- a/stats.go
+++ b/stats.go
@@ -15,6 +15,7 @@ type statsAccum struct {
 	stTblCount int
 	stEntries  int
 	stMax      int
+	stDepth    int
 	stEpsilon  int
 	stEpMax    int
 	stVisited  map[*smallTable]bool


### PR DESCRIPTION
partially addresses #66

A lot of code to parse regexps and build them into a tree from which an NFA can be generated.  It has a feature tracker and will reject quamina.AddPattern with a regexp that includes an unimplemented feature.  The only feature generated so far is ".". See REGEXP.md for details.

some of regexp_nfa.go is weakly tested since only "." is implemented so far and some code not related to that can't be reached in production.

valueMatcher.addTransition considerably re-organized for simplicity

