### PR TITLE
match_set reallocates.

### DIFF
--- a/core_matcher.go
+++ b/core_matcher.go
@@ -178,7 +178,9 @@ func (m *coreMatcher) matchesForFields(fields []Field, bufs *nfaBuffers) ([]X, e
 	} else {
 		sort.Sort(fieldsList(fields))
 	}
-	matches := newMatchSet()
+	// Reuse the matchSet from buffers to reduce allocations
+	matches := bufs.matches
+	matches.reset()
 	cmFields := m.fields()
 
 	// for each of the fields, we'll try to match the automaton start state to that field - the tryToMatch

--- a/match_set.go
+++ b/match_set.go
@@ -10,6 +10,11 @@ func newMatchSet() *matchSet {
 	return &matchSet{set: make(map[X]bool)}
 }
 
+// reset clears the matchSet for reuse, preserving the allocated map capacity.
+func (m *matchSet) reset() {
+	clear(m.set)
+}
+
 func (m *matchSet) addX(exes ...X) *matchSet {
 	if len(exes) == 0 {
 		return m

--- a/nfa.go
+++ b/nfa.go
@@ -72,6 +72,7 @@ func (tm *transmap) all() []*fieldMatcher {
 type nfaBuffers struct {
 	buf1, buf2 []*faState
 	eClosure   *epsilonClosure
+	matches    *matchSet
 }
 
 func newNfaBuffers() *nfaBuffers {
@@ -79,6 +80,7 @@ func newNfaBuffers() *nfaBuffers {
 		buf1:     make([]*faState, 0, 16),
 		buf2:     make([]*faState, 0, 16),
 		eClosure: newEpsilonClosure(),
+		matches:  newMatchSet(),
 	}
 }
 


### PR DESCRIPTION
I had Claude Code look at this. Benchmarking showed at least 36% in madvise, which means the code is fast, but there might be reallocations of arrays and/or hashtables.

It came up with a bogus optimization that shared things across test runs, but this one is fair.
