### PR TITLE
Pool transitions buffers to reduce allocations

### DIFF
--- a/nfa.go
+++ b/nfa.go
@@ -74,7 +74,7 @@ type nfaBuffers struct {
 	buf1, buf2     []*faState
 	eClosure       *epsilonClosure
 	matches        *matchSet
-	dfaTransitions []*fieldMatcher
+	transitionsBuf []*fieldMatcher
 }
 
 func newNfaBuffers() *nfaBuffers {
@@ -83,7 +83,7 @@ func newNfaBuffers() *nfaBuffers {
 		buf2:           make([]*faState, 0, 16),
 		eClosure:       newEpsilonClosure(),
 		matches:        newMatchSet(),
-		dfaTransitions: make([]*fieldMatcher, 0, 16),
+		transitionsBuf: make([]*fieldMatcher, 0, 16),
 	}
 }
 

--- a/value_matcher.go
+++ b/value_matcher.go
@@ -52,7 +52,7 @@ func newValueMatcher() *valueMatcher {
 
 func (m *valueMatcher) transitionOn(eventField *Field, bufs *nfaBuffers) []*fieldMatcher {
 	vmFields := m.fields()
-	transitions := bufs.dfaTransitions[:0]
+	transitions := bufs.transitionsBuf[:0]
 
 	val := eventField.Val
 	switch {


### PR DESCRIPTION
This change adds a dfaTransitions field to nfaBuffers and uses it in valueMatcher.transitionOn() instead of allocating a new slice for each value match operation. The buffer is reset to length 0 before each use while preserving capacity. See #470.

Reliable reduction in allocations.

Before:

```
 % go test -bench=^Benchmark8259Example$ -run=^$ 
FA: Field matchers: 2 (avg size 2.500, max 4)
Value matchers: 5
SmallTables 20371 (splices 6, avg 4.033, max 66, epsilons avg 0.001, max 2) singletons 1
97182/sec
goos: darwin
goarch: arm64
pkg: quamina.net/go/quamina
cpu: Apple M1 Ultra
Benchmark8259Example-20    	  127725	     10290 ns/op	     984 B/op	      31 allocs/op
PASS
ok  	quamina.net/go/quamina	1.620s
```

After:

```
% go test -bench=^Benchmark8259Example$ -run=^$                    
FA: Field matchers: 2 (avg size 2.500, max 4)
Value matchers: 5
SmallTables 20371 (splices 6, avg 4.033, max 66, epsilons avg 0.001, max 2) singletons 1
100830/sec
goos: darwin
goarch: arm64
pkg: quamina.net/go/quamina
cpu: Apple M1 Ultra
Benchmark8259Example-20    	  130026	      9918 ns/op	     914 B/op	      23 allocs/op
PASS
ok  	quamina.net/go/quamina	1.628s
```