### PR TITLE
Add compiling for specific architectures section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -367,11 +367,11 @@ the `GetMatcherStats()` API.
 Go compiles with [default CPU capabilites](https://go.dev/wiki/MinimumRequirements)
 for each architecture. In particular, its [AMD64](https://go.dev/wiki/MinimumRequirements#amd64)
 defaults are quite conservative. Changing this default can yield up to 10% improvements
-with no code changes, if you know the target machines' capabilites. No signifcant
-improvements have been measured by adjusting the [ARM64](https://go.dev/wiki/MinimumRequirements#arm64)
-defaults.
+with no code changes, if you know the target machines' capabilites.
 
-AMD65 test machine: AMD Threadripper 2920X machine with 64GB of RAM.
+AMD65 test machine: AMD Threadripper 2920X machine with 64GB of RAM. Tested level v1 vs v3. The performance improvements were benchmark-dependent, so it's best to check it on your own workload.
+
+No signifcant improvements have been measured by adjusting the [ARM64](https://go.dev/wiki/MinimumRequirements#arm64) defaults.
 
 ARM64 test machines: various Apple Silicon chips, M1 Ultra to M5.
 

--- a/README.md
+++ b/README.md
@@ -369,7 +369,10 @@ for each architecture. In particular, its [AMD64](https://go.dev/wiki/MinimumReq
 defaults are quite conservative. Changing this default can yield up to 10% improvements
 with no code changes, if you know the target machines' capabilites. No signifcant
 improvements have been measured by adjusting the [ARM64](https://go.dev/wiki/MinimumRequirements#arm64)
-defaults. Tested on an AMD Threadripper 2920X machine with 64GB of RAM.
+defaults.
+
+AMD65 test machine; AMD Threadripper 2920X machine with 64GB of RAM.
+ARM64 test machiens: various Apple Silicon chips, M1 Ultra to M5.
 
 ### Further documentation
 

--- a/README.md
+++ b/README.md
@@ -371,8 +371,9 @@ with no code changes, if you know the target machines' capabilites. No signifcan
 improvements have been measured by adjusting the [ARM64](https://go.dev/wiki/MinimumRequirements#arm64)
 defaults.
 
-AMD65 test machine; AMD Threadripper 2920X machine with 64GB of RAM.
-ARM64 test machiens: various Apple Silicon chips, M1 Ultra to M5.
+AMD65 test machine: AMD Threadripper 2920X machine with 64GB of RAM.
+
+ARM64 test machines: various Apple Silicon chips, M1 Ultra to M5.
 
 ### Further documentation
 

--- a/README.md
+++ b/README.md
@@ -369,7 +369,7 @@ for each architecture. In particular, its [AMD64](https://go.dev/wiki/MinimumReq
 defaults are quite conservative. Changing this default can yield up to 10% improvements
 with no code changes, if you know the target machines' capabilites. No signifcant
 improvements have been measured by adjusting the [ARM64](https://go.dev/wiki/MinimumRequirements#arm64)
-defaults.
+defaults. Tested on an AMD Threadripper 2920X machine with 64GB of RAM.
 
 ### Further documentation
 

--- a/README.md
+++ b/README.md
@@ -362,6 +362,15 @@ is very similar to the increase in the total memory used by the Pattern-matching
 data structures. The amount of total memory can be retrieved using
 the `GetMatcherStats()` API.
 
+### Compiling for specific architectures
+
+Go compiles with [default CPU capabilites](https://go.dev/wiki/MinimumRequirements)
+for each architecture. In particular, its [AMD64](https://go.dev/wiki/MinimumRequirements#amd64)
+defaults are quite conservative. Changing this default can yield up to 10% improvements
+with no code changes, if you know the target machines' capabilites. No signifcant
+improvements have been measured by adjusting the [ARM64](https://go.dev/wiki/MinimumRequirements#arm64)
+defaults.
+
 ### Further documentation
 
 There is a series of blog posts entitled


### PR DESCRIPTION
This did get a win on the matcher--Go's AMD default is really old stuff.