### PR TITLE
kaizen: typos

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -133,7 +133,7 @@ of building and submitting a PR, to type `make` at some
 point, which will rebuild and re-run `code_gen`; that program
 will display a message saying whether or not it rebuilt the
 case-folding mappings. If it did rebuild those mappings, please
-include the generated files in your commmit
+include the generated files in your commit
 and PR.
 
 ## Reporting Bugs and Creating Issues
@@ -167,7 +167,7 @@ A straightforward way to test a new feature is exemplified by `TestLongCase()` i
 3. Make test data and examine matching behavior by calling `matchesForJSONEvent()`
 
 We track test coverage carefully and while we don't have a target coverage number,
-the majority of Quamina’s source files hit 100%. Don’t scrimp on unit tsting.
+the majority of Quamina’s source files hit 100%. Don’t scrimp on unit testing.
 
 ### Prettyprinting NFAs
 

--- a/PATTERNS.md
+++ b/PATTERNS.md
@@ -13,7 +13,7 @@ Patterns exist to match **Fields** in incoming **Events**. At
 launch, Quamina supports only JSON syntax for Events. An
 Event **MUST** be equivalent to a JSON Object in the
 sense that it consists of an unordered set of members,
-each identified by a name which is string composed of
+each identified by a name which is a string composed of
 Unicode characters.
 
 As in JSON, the allowed member values may be strings,

--- a/README-pruner.md
+++ b/README-pruner.md
@@ -4,13 +4,13 @@ The core quamina.Matcher doesn't currently support deleting patterns.
 Some of the contemplated implementations would probably be pretty
 difficult.  At least one approach is pretty easy: Wrap the current
 matcher to filter removed patterns from match results and periodically
-rebuild the matcher from scrach with the live patterns.  More
+rebuild the matcher from scratch with the live patterns.  More
 specifically:
 
 1. Remember patterns that have been added
 2. Remember patterns that have been removed (implicitly)
 3. Filter `MatchesFor...()` results to remove any removed patterns
-4. Rebuilding the matcher state periodically with only the live
+4. Rebuild the matcher state periodically with only the live
    patterns
 5. Maintain some statistics to help decide when to rebuild
 
@@ -21,7 +21,7 @@ persistence.
 
 By default, rebuilding is triggered automatically (synchronously
 currently) during mutations.  You can also force a manual `Rebuild()`,
-and you can `DisableRebuild()` to prevent any automation rebuilds.
+and you can `DisableRebuild()` to prevent any automatic rebuilds.
 The code also supports pluggable rebuilding policies, but those
 features are not currently exposed.
 

--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ q, err := quamina.New(quamina.WithMediaType("application/json"))
 ```
 The meanings of the `Option` functions are:
 
-`WithMediaType`: In the futue, Quamina will support
+`WithMediaType`: In the future, Quamina will support
 Events not just in JSON but in other formats such as
 Avro, Protobufs, and so on. This option will make sure
 to invoke the correct Flattener. At the moment, the only
@@ -192,7 +192,7 @@ Note that if you choose this option, the `SetMatcherBuildMode`
 API will be disabled. This is a bug and will be fixed.
 
 `WithPatternStorage`: If you provide an argument that
-supports the `LivePatternStorage` API, Quamina will
+supports the `LivePatternsState` API, Quamina will
 use it to maintain a list of which Patterns have currently
 been added but not deleted. This could be useful if you
 wanted to rebuild Quamina instances for sharded
@@ -208,7 +208,7 @@ func (q *Quamina) GetMatcherBuildMode() MatcherBuildMode
 There are two Matcher Build Modes, `BuiltForComfort` and `BuiltForSpeed`.  The mode controls the
 behavior of the `AddPattern()` API. When in the default `BuiltForComfort` mode, adding Patterns
 which include wildcards and regexps will result in `MatchesForEvent()` performance that declines
-roughly linearly as a function of of the number of such Patterns added.
+roughly linearly as a function of the number of such Patterns added.
 
 When `AddPattern()` is in `BuiltForSpeed` mode, adding such Patterns results in `MatchesForEvent()`
 performance that is only weakly related to the number of Patterns added and in practice is much 

--- a/REGEXP.md
+++ b/REGEXP.md
@@ -37,7 +37,7 @@ The following list identifies the features of Quamina regular expressions.
 
 **`[^]` : complementary character-class matcher**
 
-**`()` : parenthetized sub-regexp**
+**`()` : parenthesized sub-regexp**
 
 **`?` : optional matcher**
 
@@ -53,7 +53,7 @@ The following list identifies the features of Quamina regular expressions.
 
 ## What to watch out for
 
-The `-p{}` and `~P{}` patterns can require building state machines that match tens of thousands
+The `~p{}` and `~P{}` patterns can require building state machines that match tens of thousands
 of characters scattered across the entire Unicode codespace. The cost in computation and memory, when
 adding such patterns, can be very high. However, the runtime performance in matching such patterns,
 once built, remains good.

--- a/anything_but.go
+++ b/anything_but.go
@@ -65,7 +65,7 @@ func readAnythingButSpecial(pb *patternBuild, valsIn []typedVal) (pathVals []typ
 // A finite automaton that matches anything but one byte sequence is like this:
 // For each byte in val with value Z, we produce a table that leads to a nextField match on all non-Z values,
 // and to another such table for Z. After all the bytes have matched, a match on valueTerminator leads to
-// an empty table with no field Transitions, all others to a nexField match
+// an empty table with no field Transitions, all others to a nextField match
 //
 // Making a succession of anything-but automata for each of "a" and "b" and then merging them turns out not
 // to work because what the caller means is really an AND - everything that matches neither "a" nor "b". So

--- a/benchmarks_test.go
+++ b/benchmarks_test.go
@@ -113,7 +113,7 @@ func TestMySoftwareHatesMe(t *testing.T) {
 	}
 }
 
-// exercise shellstyle matching a little, is much faster than TestCityLots because it's only working wth one field
+// exercise shellstyle matching a little, is much faster than TestCityLots because it's only working with one field
 func TestBigShellStyle(t *testing.T) {
 	lines := getCityLotsLines(t)
 	bufs := newNfaBuffers()
@@ -185,7 +185,7 @@ func TestBigShellStyle(t *testing.T) {
 	}
 }
 
-// TestPatternAddition adds a whole lot of string-only rules as fast as possible  The profiler says that the
+// TestPatternAddition adds a whole lot of string-only rules as fast as possible. The profiler says that the
 // performance is totally dominated by the garbage-collector thrashing, in particular it has to allocate
 // ~220K smallTables.  Tried https://blog.twitch.tv/en/2019/04/10/go-memory-ballast-how-i-learnt-to-stop-worrying-and-love-the-heap/
 // but it doesn't seem to help.

--- a/cl2_test.go
+++ b/cl2_test.go
@@ -16,7 +16,7 @@ var (
 	cl2LineCount int
 )
 
-// test rules pulled out so that it's easy to write test funcs focusing in on one set of htem.
+// test rules pulled out so that it's easy to write test funcs focusing in on one set of them.
 var (
 	anythingButRules = []string{
 		"{\n" +

--- a/code_gen/build_unicode_tables.go
+++ b/code_gen/build_unicode_tables.go
@@ -167,7 +167,7 @@ func buildCharPropsTable() {
 		sortedProps = append(sortedProps, property)
 	}
 
-	// arrange the maps in alphabetical order for aesthatic reasons
+	// arrange the maps in alphabetical order for aesthetic reasons
 	slices.Sort(sortedProps)
 
 	for _, prop := range sortedProps {

--- a/flatten_json.go
+++ b/flatten_json.go
@@ -149,7 +149,7 @@ func (fj *flattenJSON) readObject(pathNode SegmentsTreeTracker) error {
 		return err
 	}
 
-	// how many leaf states (fieldsCount) and chidStructures (nodesCount) have been mentioned in patterns?
+	// how many leaf states (fieldsCount) and childStructures (nodesCount) have been mentioned in patterns?
 	fieldsCount := pathNode.FieldsCount()
 	nodesCount := pathNode.NodesCount()
 
@@ -178,7 +178,7 @@ func (fj *flattenJSON) readObject(pathNode SegmentsTreeTracker) error {
 	var segmentIsUsed bool
 	isLeaf := false
 	for {
-		// if we've read all the nodes and fields tha have been mentioned in Patterns, we can stop reading this object
+		// if we've read all the nodes and fields that have been mentioned in Patterns, we can stop reading this object
 		if nodesCount == 0 && fieldsCount == 0 {
 			if pathNode.IsRoot() {
 				return errEarlyStop
@@ -629,7 +629,7 @@ func (fj *flattenJSON) skipStringValue() error {
 // ideally, we'd like to construct the member name as just a slice of the event buffer,
 // but will have to find a new home for it if it has JSON \-escapes
 func (fj *flattenJSON) readStringValue() ([]byte, error) {
-	// value includes leading and trailng "
+	// value includes leading and trailing "
 	valStart := fj.eventIndex
 	fj.eventIndex++
 	if fj.eventIndex >= len(fj.event) {

--- a/flattener.go
+++ b/flattener.go
@@ -16,7 +16,7 @@ package quamina
 //	"f", "\"x\""
 //
 // Let's call the first column, eg "d" and "e\ne1", the path. For each
-// step i the path, e.g. "d" and "e1", the Flattener should utilize SegmentsTreeTracker to
+// step in the path, e.g. "d" and "e1", the Flattener should utilize SegmentsTreeTracker to
 // traverse the hierarchy and select only the needed fields.
 type Flattener interface {
 	Flatten(event []byte, tracker SegmentsTreeTracker) ([]Field, error)

--- a/nfa.go
+++ b/nfa.go
@@ -173,7 +173,7 @@ func n2dNode(rawNStates []*faState, sList *stateLists) *faState {
 		}
 	}
 
-	// the collection of states may have duplicates and, deduplicated, considered'
+	// the collection of states may have duplicates and, deduplicated, considered
 	// as a set, may be equal to a previous set of states, in which case the
 	// corresponding DFA will have already been constructed.
 	ingredients, dfaState, alreadyExists := sList.intern(nStates)

--- a/nfa_test.go
+++ b/nfa_test.go
@@ -7,7 +7,7 @@ import (
 	"unsafe"
 )
 
-// TestArrayBehavior is here prove that (a) you can index a map with an array and
+// TestArrayBehavior is here to prove that (a) you can index a map with an array and
 // the indexing actually relies on the values in the array. This has nothing to do with
 // Quamina, but I'm leaving it here because I had to write this stupid test after failing
 // to find a straightforward question of whether this works as expected anywhere in the

--- a/pruner.go
+++ b/pruner.go
@@ -20,11 +20,11 @@ type prunerStats struct {
 	// Deleted is the count of the patterns removed.
 	Deleted int
 
-	// Emitted is the count to total patterns found since the last
+	// Emitted is the count of total patterns found since the last
 	// rebuildWhileLocked.
 	Emitted int64
 
-	// Filtered is the count of pattners that have been removed
+	// Filtered is the count of patterns that have been removed
 	// from MatchFor results (since the last rebuildWhileLocked) because
 	// their patterns had been removed.
 	Filtered int64
@@ -155,7 +155,7 @@ func (m *prunerMatcher) disableRebuild() {
 type rebuildTrigger interface {
 	// rebuild should return true to trigger a rebuild.
 	//
-	// This method is called by AddPatter,deletePatterns, and
+	// This method is called by AddPattern, deletePatterns, and
 	// matchesForFields.  added is true when called by addPattern;
 	// false otherwise. These methods currently do not return
 	// until the rebuild is complete, so beware.

--- a/quamina.go
+++ b/quamina.go
@@ -171,9 +171,9 @@ func (q *Quamina) GetMatcherStats() map[string]float64 {
 
 // MatcherBuildMode enumerates the modes a Quamina instance can be in. The default is BuiltForComfort.
 // When a Quamina instance is in BuiltForComfort mode, adding Patterns which include wildcards and regexps
-// results in NFA-based matchers, which are more compact and faster to build, but result in MatchesForEvent
+// result in NFA-based matchers. These are more compact and faster to build, but result in MatchesForEvent
 // performance slowing down as a fairly linear function of the number of such patterns added.
-// When an instance is in BuiltForSpeed mode, the NFAs which implemnet wildcard and regexp Patterns are converted
+// When an instance is in BuiltForSpeed mode, the NFAs which implement wildcard and regexp Patterns are converted
 // to DFAs. As a result, the performance of MatchesForEvent is only very weakly related to the number of
 // Patterns added and in practice is much faster.  However, certain combinations of such patterns can result
 // in explosive growth of the size of the Matcher and the AddPattern latency.  This can be as bad as O(2**N)
@@ -208,7 +208,7 @@ func (q *Quamina) SetMemoryBudget(budget uint64) (uint64, error) {
 	return 0, errors.New("the MemoryBudget API is deprecated")
 }
 
-// GetMemoryBudget is depcrecated; see the comment on SetMemoryBudget
+// GetMemoryBudget is deprecated; see the comment on SetMemoryBudget
 func (q *Quamina) GetMemoryBudget() (uint64, uint64) {
 	return 0, 0
 }

--- a/quamina_test.go
+++ b/quamina_test.go
@@ -112,7 +112,7 @@ func TestNewQOptions(t *testing.T) {
 const thresholdPerformance = 1.0
 
 // TestCityLots is the benchmark that was used in most of Quamina's performance tuning.  It's fairly pessimal in
-// that it uses geometry/co-ordintes, which will force the fj flattener to process the big arrays of numbers in
+// that it uses geometry/co-ordinates, which will force the fj flattener to process the big arrays of numbers in
 // each line.  A high proportion of typical Quamina workloads should run faster.
 func TestCityLots(t *testing.T) {
 	patterns := []string{

--- a/regexp_reader.go
+++ b/regexp_reader.go
@@ -29,7 +29,7 @@ const (
 	rxfPlus            regexpFeature = "'+' one-or-more matcher"
 	rxfQM              regexpFeature = "'?' optional matcher"
 	rxfRange           regexpFeature = "'{}' range matcher"
-	rxfParenGroup      regexpFeature = "() parenthetized group"
+	rxfParenGroup      regexpFeature = "() parenthesized group"
 	rxfProperty        regexpFeature = "~p-prefixed {}-enclosed Unicode property matcher"
 	rxfNegatedProperty regexpFeature = "~P-prefixed {}-enclosed negated property matcher"
 	rxfClass           regexpFeature = "[]-enclosed character-class matcher"

--- a/regexp_validity_test.go
+++ b/regexp_validity_test.go
@@ -152,7 +152,7 @@ func TestRegexpValidity(t *testing.T) {
 					bufs := newNfaBuffers()
 					fields := testTraverseNFA(table, []byte(`"`+shouldNot+`"`), transitions, bufs)
 					if len(fields) != 0 {
-						// similarly, it says quite a lot of empty strins should not match regexps that
+						// similarly, it says quite a lot of empty strings should not match regexps that
 						// have stars and *should* match them
 						if len(shouldNot) == 0 && !starSamplesMatchingEmpty[sample.regex] {
 							t.Errorf("<%s> matched /%s/", shouldNot, sample.regex)

--- a/rune_range.go
+++ b/rune_range.go
@@ -11,7 +11,7 @@ import (
 // RuneRange FAs, we compute and cache shells. A shell is an FA computed with the "next" value
 // being PlaceholderState.  When you need a rune range FA, you take the shell and build a copy,
 // replacing transitions to PlaceholderState by whatever the "next" value is.
-// Note that FAs are only built during AddPattern calls and this is single-threaded, se we
+// Note that FAs are only built during AddPattern calls and this is single-threaded, so we
 // can safely build and update the cachedRRFaShells
 
 var PlaceholderState *faState = &faState{table: newSmallTable()}

--- a/segments_tree.go
+++ b/segments_tree.go
@@ -13,7 +13,7 @@ type segmentsTree struct {
 	root bool
 
 	// nodes stores a map from a segment to its children.
-	// in a hierarchial data format like JSON, a node can be Object or Array.
+	// in a hierarchical data format like JSON, a node can be Object or Array.
 	// for example, in this path "context\nuser\nid", both "context" and "user" will be nodes.
 	nodes map[string]*segmentsTree
 

--- a/segments_tree_tracker.go
+++ b/segments_tree_tracker.go
@@ -1,7 +1,7 @@
 package quamina
 
-// SegmentsTreeTracker is an interface used by Flattener to represents all the paths mentioned
-// Patterns added to a Quamina instance in AddPattern() calls. It allows a Flattener to determine
+// SegmentsTreeTracker is an interface used by Flattener to represent all the paths mentioned
+// in Patterns added to a Quamina instance in AddPattern() calls. It allows a Flattener to determine
 // which Event fields may safely be ignored, and also caches the runtime form of the Field.Path
 // value.
 //
@@ -16,13 +16,13 @@ package quamina
 //	 [ "a" ] -> as node
 //	   |-> with fields of: "b" and "c"
 //
-// This allow us to traverse the hierarchial data together with the segments tree,
+// This allows us to traverse the hierarchical data together with the segments tree,
 // fetch a node and answer:
-//   - Is the current segment is used? (JSON - is the current property needs to be selected)
-//   - Do we need to traverse into this Node as well? (JSON - do we need traverse this object?)
-//   - How much fields & nodes we have to traverse in the current hierarchy until we are finished?
+//   - Is the current segment used? (JSON - does the current property need to be selected)
+//   - Do we need to traverse into this Node as well? (JSON - do we need to traverse this object?)
+//   - How many fields & nodes we have to traverse in the current hierarchy until we are finished?
 //     for example: in the current level, in the tree node we have 1 node and 2 fields
-//     we finishded selecting them, can we finish traversing this node?
+//     we finished selecting them, can we finish traversing this node?
 type SegmentsTreeTracker interface {
 	// Get returns another level of the hierarchy, referred as "Node"
 	// If a node is returned we will need to traverse into (in JSON/CBOR/ProtoBuf/etc..)
@@ -39,7 +39,7 @@ type SegmentsTreeTracker interface {
 
 	// When a Flattener reaches the last (leaf) step of a path, this returns the full
 	// path-name for that Field.  This is an optimization; since these need to be calculated
-	// while executing `ddPattern, we might as wewll remember them for use during Flattening.
+	// while executing `AddPattern`, we might as well remember them for use during Flattening.
 	PathForSegment(name []byte) []byte
 
 	// Called by the Flattener to return the number of nodes (non-leaf children) and fields

--- a/value_matcher.go
+++ b/value_matcher.go
@@ -58,7 +58,7 @@ func (m *valueMatcher) transitionOn(eventField *Field, bufs *nfaBuffers) []*fiel
 	switch {
 	case vmFields.singletonMatch != nil:
 		// if there's a singleton entry here, we either match the val or we're
-		// done Note: We have to check this first because addTransition might be
+		// done. Note: We have to check this first because addTransition might be
 		// busy constructing an automaton, but it's not ready for use yet.  When
 		// it's done it'll zero out the singletonMatch
 		if bytes.Equal(vmFields.singletonMatch, val) {


### PR DESCRIPTION
I noticed I wrote "AMD65" in the README, but figured I might as well have Claude scan everything.

Corrects ~40 spelling and grammar mistakes in user-facing docs (README, PATTERNS, REGEXP, README-pruner, CONTRIBUTING), source-file comments, and test comments, including the doubled word and "implemnet" typo introduced by the comfort-and-speed work. Comment/prose only; no code behavior changes (build and vet pass).