### PR TITLE
kaizen: fix typos in README "Compiling for specific architectures"

### DIFF
--- a/README.md
+++ b/README.md
@@ -387,14 +387,14 @@ until you get into hundreds of such patterns.
 
 ### Compiling for specific architectures
 
-Go compiles with [default CPU capabilites](https://go.dev/wiki/MinimumRequirements)
+Go compiles with [default CPU capabilities](https://go.dev/wiki/MinimumRequirements)
 for each architecture. In particular, its [AMD64](https://go.dev/wiki/MinimumRequirements#amd64)
 defaults are quite conservative. Changing this default can yield up to 10% improvements
-with no code changes, if you know the target machines' capabilites.
+with no code changes, if you know the target machines' capabilities.
 
-AMD65 test machine: AMD Threadripper 2920X machine with 64GB of RAM. Tested level v1 vs v3. The performance improvements were benchmark-dependent, so it's best to check it on your own workload.
+AMD64 test machine: AMD Threadripper 2920X machine with 64GB of RAM. Tested level v1 vs v3. The performance improvements were benchmark-dependent, so it's best to check it on your own workload.
 
-No signifcant improvements have been measured by adjusting the [ARM64](https://go.dev/wiki/MinimumRequirements#arm64) defaults.
+No significant improvements have been measured by adjusting the [ARM64](https://go.dev/wiki/MinimumRequirements#arm64) defaults.
 
 ARM64 test machines: various Apple Silicon chips, M1 Ultra to M5.
 
@@ -432,4 +432,3 @@ colonies before slavery was abolished.
 @arnehormann: Compact high-precision number representation.
 
 @sayrer: Generation and curation of AI-based optimizations.
-


### PR DESCRIPTION
Missed the ones I was originally looking at. These are all my mistakes.