### PR TITLE
pat: treat {0,} quantifier as * to avoid nil-pointer panic

### DIFF
--- a/regexp_nfa.go
+++ b/regexp_nfa.go
@@ -124,6 +124,14 @@ func faFromQuantifiedAtom(branch regexpBranch, index int, finalStep *faState, pp
 		state.table.epsilons = []*faState{nextState}
 
 	case atom.isMinimumOnly():
+		// {0,} has no mandatory steps, so it means the same thing as *
+		if atom.quantMin == 0 {
+			state = &faState{}
+			state.table = atom.makeFA(state, pp)
+			state.table.epsilons = append(state.table.epsilons, nextState)
+			break
+		}
+
 		shellTable := atom.makeFA(PlaceholderState, pp)
 		nextMinMaxStep := nextState
 

--- a/regexp_samples_test.go
+++ b/regexp_samples_test.go
@@ -5447,4 +5447,11 @@ var regexpSamples = []regexpSample{
 		regex: "[~i]",
 		valid: false,
 	},
+	// {0,} has no mandatory steps so it means the same as *; used to panic, see #558
+	{
+		regex:     "x{0,}y",
+		matches:   []string{"y", "xy", "xxxy"},
+		nomatches: []string{"x", "z", "xx"},
+		valid:     true,
+	},
 }


### PR DESCRIPTION
Fixes #558. The `isMinimumOnly` branch in `faFromQuantifiedAtom` builds a chain of mandatory steps and then loops the last one back, but for `{0,}` the loop runs zero times, so `lastState` stays nil and the append on it panics. `{0,}` has no mandatory steps and means the same thing as `*`, so I handle that case the same way the `*` branch does.

Added an `x{0,}y` entry to `regexpSamples` (matches `y`/`xy`/`xxxy`, rejects `x`/`z`/`xx`); without the fix it panics during NFA construction.
