### PR TITLE
fix: add recovery for poison-pill input

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,8 +247,8 @@ must be a JSON object as exemplified above in this document.
 The `error` return is used to signal either invalid Pattern
 structure, which could be bad UTF-8 or malformed JSON
 or leaf values which are not provided as arrays, or that
-adding this Pattern would exceed the specified memory budget
-(see above).
+this Pattern was sufficiently large or deeply nested that 
+building the matcher structures caused a memory exception.
 
 As many Patterns as desired can be added to a Quamina
 instance. More than one Pattern can be added with the
@@ -269,7 +269,9 @@ internal failure of Quamina’s storage system.
 func (q *Quamina) MatchesForEvent(event []byte) ([]X, error)
 ```
 The `error` return value is nil unless there was an
-error in the encoding of the Event.
+error in the encoding of the Event, or it
+was sufficiently large or deeply nested that
+processing it caused a memory exception
 
 The `[]X` return slice may be empty if none of the Patterns
 match the provided Event.

--- a/core_matcher.go
+++ b/core_matcher.go
@@ -63,7 +63,13 @@ func (m *coreMatcher) addPattern(x X, patternJSON string, buildMode MatcherBuild
 
 // addPatternWithPrinter can be called from debugging and under-development code to allow viewing pretty-printed
 // NFAs
-func (m *coreMatcher) addPatternWithPrinter(x X, patternJSON string, printer printer, buildMode MatcherBuildMode) error {
+func (m *coreMatcher) addPatternWithPrinter(x X, patternJSON string, printer printer, buildMode MatcherBuildMode) (err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = errors.New("call to AddPattern caused a crash, probably because the Pattern is too large or too deeply nested")
+		}
+	}()
+
 	patternFields, err := patternFromJSON([]byte(patternJSON))
 	if err != nil {
 		return err
@@ -127,7 +133,6 @@ func (m *coreMatcher) addPatternWithPrinter(x X, patternJSON string, printer pri
 		endState.addMatch(x)
 	}
 	m.updateable.Store(freshStart)
-
 	return nil
 }
 
@@ -183,16 +188,23 @@ func emptyFields() []Field {
 
 // matchesForFields takes a list of Field structures, sorts them by pathname, and launches the field-matching
 // process. The fields in a pattern to match are similarly sorted; thus running an automaton over them works.
-// No error can be returned but the matcher interface requires one, and it is used by the pruner implementation
-func (m *coreMatcher) matchesForFields(fields []Field, bufs *nfaBuffers) ([]X, error) {
+func (m *coreMatcher) matchesForFields(fields []Field, bufs *nfaBuffers) (matches []X, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = errors.New("call to MatchesForEvent caused a crash, probably because the Event is too large or too deeply nested")
+		}
+	}()
+
 	if len(fields) == 0 {
 		fields = emptyFields()
 	} else {
 		slices.SortFunc(fields, func(a, b Field) int { return bytes.Compare(a.Path, b.Path) })
 	}
+
 	// Reuse the matchSet from buffers to reduce allocations
-	matches := bufs.getMatches()
-	matches.reset()
+	matchSet := bufs.getMatches()
+	matchSet.reset()
+
 	// Reset transmap depth for this match operation
 	if tm := bufs.transmap; tm != nil {
 		tm.resetDepth()
@@ -203,9 +215,10 @@ func (m *coreMatcher) matchesForFields(fields []Field, bufs *nfaBuffers) ([]X, e
 	// routine will, in the case that there's a match, call itself to see if subsequent fields after the
 	// first matched will transition through the machine and eventually achieve a match
 	for i := 0; i < len(fields); i++ {
-		tryToMatch(fields, i, cmFields.state, matches, bufs)
+		tryToMatch(fields, i, cmFields.state, matchSet, bufs)
 	}
-	return matches.matchesInto(bufs.resultBuf[:0]), nil
+	matches = matchSet.matchesInto(bufs.resultBuf[:0])
+	return
 }
 
 // tryToMatch tries to match the field at fields[index] to the provided state. If it does match and generate

--- a/quamina.go
+++ b/quamina.go
@@ -200,7 +200,7 @@ func (q *Quamina) GetMatcherBuildMode() MatcherBuildMode {
 // SetMemoryBudget used to set an approximate limit on the number of bytes allocated in building matchers for complex
 // patterns. However, it proved difficult to find an implementation that was both deterministic and had
 // acceptable cost. Thus, this method is deprecated.
-func (q *Quamina) SetMemoryBudget(budget uint64) (uint64, error) {
+func (q *Quamina) SetMemoryBudget(_ uint64) (uint64, error) {
 	return 0, errors.New("the MemoryBudget API is deprecated")
 }
 

--- a/quamina_test.go
+++ b/quamina_test.go
@@ -189,3 +189,13 @@ func TestCityLots(t *testing.T) {
 		}
 	}
 }
+
+/* For this test to work, you need to force a panic in either AddPattern() for MatchesForEvent()
+func TestRecovery(t *testing.T) {
+	q, _ := New()
+	err := q.AddPattern("x", `{"x":[1]}`)
+	if err == nil {
+		t.Error("Should fail")
+	}
+}
+*/


### PR DESCRIPTION
related to #437 #557

The idea is that in theory, injecting a big enough Event or Pattern could force an OOM fault.  I tried hard to do this, but couldn't manage to push Quamina over the edge.  Having said that, this is a beefy Mac laptop and Quamina is likely running on some much more constrained cloud instance, so it makes sense to, as #557 suggests, put in a recover() to catch such a crash and turn it into a polite helpful error message.

The only fly in the ointment is that I couldn't test this functionality in the standard test suite because, as noted, it's really hard to force such a crash.  There is a test in quamina_test.go but it's commented out and, to exercise it, you have to inject a manual panic() call into one or both of MatchesForEvent or AddPattern.